### PR TITLE
fix: sync boss counts from Blizzard Journal API

### DIFF
--- a/src/sv_common/guild_sync/blizzard_client.py
+++ b/src/sv_common/guild_sync/blizzard_client.py
@@ -465,6 +465,17 @@ class BlizzardClient:
             params={"namespace": "dynamic-us", "locale": self.locale},
         )
 
+    async def get_journal_instance(self, instance_id: int) -> dict | None:
+        """GET /data/wow/journal-instance/{id} — authoritative encounter list for a raid/dungeon.
+
+        Uses the static-us namespace (not player-dependent). The response
+        includes an encounters.encounters list with one entry per boss.
+        """
+        return await self._api_get(
+            f"/data/wow/journal-instance/{instance_id}",
+            params={"namespace": "static-us", "locale": self.locale},
+        )
+
     async def sync_full_roster(
         self,
         rank_map: dict[int, str] | None = None,

--- a/src/sv_common/guild_sync/progression_sync.py
+++ b/src/sv_common/guild_sync/progression_sync.py
@@ -160,6 +160,64 @@ async def sync_raid_progress(
 
 
 # ---------------------------------------------------------------------------
+# Journal-based boss count sync
+# ---------------------------------------------------------------------------
+
+
+async def sync_boss_counts_from_journal(
+    pool: asyncpg.Pool,
+    client: BlizzardClient,
+    raid_ids: list[int],
+) -> dict:
+    """Update raid_boss_counts from the Blizzard Journal API (authoritative).
+
+    Unlike the player profile endpoint, the Journal API returns the full
+    encounter list regardless of player progress or when the raid was first
+    synced. This ensures boss counts are correct after progressive releases.
+
+    Writes one row per (raid_id, difficulty) — same difficulties used by
+    character_raid_progress: normal, heroic, mythic.
+    """
+    if not raid_ids:
+        return {"updated": 0, "errors": 0}
+
+    stats = {"updated": 0, "errors": 0}
+    difficulties = ["normal", "heroic", "mythic"]
+
+    async with pool.acquire() as conn:
+        for raid_id in raid_ids:
+            data = await client.get_journal_instance(raid_id)
+            if not data:
+                logger.warning("Journal instance fetch returned nothing for raid_id=%d", raid_id)
+                stats["errors"] += 1
+                continue
+
+            encounters = data.get("encounters", {}).get("encounters", [])
+            boss_count = len(encounters)
+            if boss_count == 0:
+                logger.warning("Journal instance %d returned 0 encounters — skipping", raid_id)
+                stats["errors"] += 1
+                continue
+
+            logger.info("Journal: raid_id=%d has %d encounters", raid_id, boss_count)
+            for difficulty in difficulties:
+                await conn.execute(
+                    """
+                    INSERT INTO guild_identity.raid_boss_counts
+                        (raid_id, difficulty, boss_count)
+                    VALUES ($1, $2, $3)
+                    ON CONFLICT (raid_id, difficulty)
+                    DO UPDATE SET boss_count = EXCLUDED.boss_count
+                    """,
+                    raid_id, difficulty, boss_count,
+                )
+                stats["updated"] += 1
+
+    logger.info("Boss count journal sync: %d rows updated, %d errors", stats["updated"], stats["errors"])
+    return stats
+
+
+# ---------------------------------------------------------------------------
 # Mythic+ keystone profiles
 # ---------------------------------------------------------------------------
 

--- a/src/sv_common/guild_sync/scheduler.py
+++ b/src/sv_common/guild_sync/scheduler.py
@@ -37,6 +37,7 @@ from .progression_sync import (
     sync_mythic_plus,
     sync_achievements,
     sync_raiderio_profiles,
+    sync_boss_counts_from_journal,
     create_weekly_snapshot,
     update_last_progression_sync,
 )
@@ -320,13 +321,33 @@ class GuildSyncScheduler:
                 try:
                     # M+ season ID comes from raid_seasons (single source of truth).
                     mplus_season_id = None
+                    current_raid_ids: list[int] = []
                     async with self.db_pool.acquire() as _conn:
                         _season_row = await _conn.fetchrow(
-                            """SELECT blizzard_mplus_season_id FROM patt.raid_seasons
+                            """SELECT blizzard_mplus_season_id, current_raid_ids
+                               FROM patt.raid_seasons
                                WHERE is_active = TRUE ORDER BY start_date DESC LIMIT 1"""
                         )
-                        if _season_row and _season_row["blizzard_mplus_season_id"]:
-                            mplus_season_id = _season_row["blizzard_mplus_season_id"]
+                        if _season_row:
+                            if _season_row["blizzard_mplus_season_id"]:
+                                mplus_season_id = _season_row["blizzard_mplus_season_id"]
+                            if _season_row["current_raid_ids"]:
+                                current_raid_ids = list(_season_row["current_raid_ids"])
+
+                    # Update boss counts from Journal API (authoritative, not player-dependent).
+                    # Runs every sync to catch progressive releases without requiring a migration.
+                    if current_raid_ids:
+                        try:
+                            journal_stats = await sync_boss_counts_from_journal(
+                                self.db_pool, self.blizzard_client, current_raid_ids
+                            )
+                            logger.info("Journal boss count sync: %s", journal_stats)
+                        except Exception as journal_exc:
+                            logger.warning(
+                                "Journal boss count sync failed (non-fatal): %s", journal_exc,
+                                exc_info=True,
+                            )
+
                     progression_chars, total_chars = await load_characters_for_progression_sync(
                         self.db_pool
                     )


### PR DESCRIPTION
## Summary
- Boss counts shown in progression strings (e.g. `4/6 H`) were stale from progressive raid release; the `/encounters/raids` player profile endpoint recorded `total_count=6` when the first wing synced, and subsequent syncs just overwrote with the same stale value
- Added `get_journal_instance()` to `BlizzardClient` — the Journal API (`/data/wow/journal-instance/{id}`) is authoritative and player-independent, returning all encounters for an instance regardless of kill state
- Added `sync_boss_counts_from_journal()` in `progression_sync.py` — fetches encounter count per current raid ID and upserts into `raid_boss_counts` for all three difficulties
- Wired into the Blizzard sync pipeline in `scheduler.py` — runs each 6-hour cycle, non-fatal on error, self-corrects without any DB migration

## Test plan
- [ ] Merge to main — test auto-deploys, verify no startup errors in logs
- [ ] Wait for or trigger Blizzard sync on test — confirm log line `Journal: raid_id=X has 9 encounters`
- [ ] Check roster/my-characters shows correct `X/9` progression strings
- [ ] Tag for prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)