### PR TITLE
feat: bulk populate gear plans (GL admin action)

### DIFF
--- a/src/guild_portal/api/bis_routes.py
+++ b/src/guild_portal/api/bis_routes.py
@@ -33,6 +33,7 @@ from datetime import datetime, timezone
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from guild_portal.deps import get_db, require_rank
@@ -811,3 +812,59 @@ async def delete_item_source(
     if deleted == "0":
         raise HTTPException(status_code=404, detail="Source entry not found")
     return {"ok": True}
+
+
+@router.post("/bulk-populate-plans")
+async def bulk_populate_plans(
+    request: Request, player: Player = Depends(require_rank(5))
+):
+    """Populate unlocked BIS slots for all in-guild characters (GL only).
+
+    For every in-guild character linked to any player, creates a gear plan if one
+    doesn't exist (using the character's active spec) then fills all unlocked slots
+    from the Wowhead Overall BIS source.  Returns counts of characters processed
+    and total slots populated.
+    """
+    from guild_portal.services import gear_plan_service as svc
+
+    pool = _pool(request)
+
+    async with pool.acquire() as conn:
+        wowhead_src = await conn.fetchrow(
+            "SELECT id FROM guild_identity.bis_list_sources WHERE name = 'Wowhead Overall' LIMIT 1"
+        )
+        wowhead_source_id = wowhead_src["id"] if wowhead_src else None
+
+        rows = await conn.fetch(
+            """
+            SELECT DISTINCT p.id AS player_id, wc.id AS character_id
+              FROM guild_identity.players p
+              JOIN guild_identity.player_characters pc ON pc.player_id = p.id
+              JOIN guild_identity.wow_characters wc ON wc.id = pc.character_id
+             WHERE wc.in_guild = TRUE
+               AND wc.removed_at IS NULL
+             ORDER BY p.id, wc.id
+            """
+        )
+
+    characters_processed = 0
+    slots_populated = 0
+
+    for row in rows:
+        player_id = row["player_id"]
+        character_id = row["character_id"]
+
+        await svc.get_or_create_plan(pool, player_id, character_id)
+        populated = await svc.populate_from_bis(
+            pool, player_id, character_id, source_id=wowhead_source_id
+        )
+        slots_populated += populated
+        characters_processed += 1
+
+    return JSONResponse({
+        "ok": True,
+        "data": {
+            "characters_processed": characters_processed,
+            "slots_populated": slots_populated,
+        },
+    })

--- a/src/guild_portal/static/js/gear_plan_admin.js
+++ b/src/guild_portal/static/js/gear_plan_admin.js
@@ -1823,3 +1823,24 @@ async function flagJunkSources() {
         if (btn) btn.disabled = false;
     }
 }
+
+async function bulkPopulatePlans() {
+    const btn = document.getElementById('bulk-populate-btn');
+    const result = document.getElementById('bulk-populate-result');
+    if (btn) btn.disabled = true;
+    if (result) result.textContent = '';
+    setStatus('Populating all plans from Wowhead Overall…', 'info');
+    try {
+        const r = await fetch('/api/v1/admin/bis/bulk-populate-plans', { method: 'POST' });
+        const d = await r.json();
+        if (!d.ok) throw new Error(d.error || 'Failed');
+        const msg = `Done — ${d.data.characters_processed} characters processed, ${d.data.slots_populated} slots populated.`;
+        setStatus(msg, 'success');
+        if (result) result.textContent = msg;
+    } catch (err) {
+        setStatus('Bulk populate failed: ' + err.message, 'error');
+        if (result) result.textContent = 'Error: ' + err.message;
+    } finally {
+        if (btn) btn.disabled = false;
+    }
+}

--- a/src/guild_portal/templates/admin/gear_plan.html
+++ b/src/guild_portal/templates/admin/gear_plan.html
@@ -544,6 +544,19 @@ select.gp-select {
             </div>
         </div>
 
+        {# Step 6 — Bulk Populate Player Plans #}
+        <div class="gp-step">
+            <div class="gp-step__header">
+                <span class="gp-step__num">Step 6</span>
+                <span class="gp-step__title">Bulk Populate Player Plans</span>
+            </div>
+            <p class="gp-step__desc">Create gear plans for all in-guild characters that don't have one, then fill every unlocked slot from <strong>Wowhead Overall</strong>. Skips locked slots. Safe to re-run.</p>
+            <div class="gp-step__controls">
+                <button id="bulk-populate-btn" class="btn-sm btn-primary" onclick="bulkPopulatePlans()">Populate All Plans</button>
+            </div>
+            <div class="gp-step__lastrun" id="bulk-populate-result"></div>
+        </div>
+
     </div>
     {% else %}
     {# Read-only: just show the matrix refresh #}


### PR DESCRIPTION
## Summary
- Adds `POST /api/v1/admin/bis/bulk-populate-plans` (GL only, rank 5)
- Creates gear plans for all in-guild characters that don't have one yet
- Fills every unlocked slot from **Wowhead Overall** BIS source
- New **Step 6** on `/admin/gear-plan` with button + result display
- No migration needed

## Test plan
- [ ] Deploy to dev, log in as GL, go to `/admin/gear-plan`
- [ ] Step 6 "Populate All Plans" button is visible
- [ ] Click it — status bar shows progress, then success message with character count and slots populated
- [ ] Check a character's gear plan on `/my-characters` — BIS slots filled

🤖 Generated with [Claude Code](https://claude.com/claude-code)