### PR TITLE
feat: gear plan controls revisited

### DIFF
--- a/src/guild_portal/api/gear_plan_routes.py
+++ b/src/guild_portal/api/gear_plan_routes.py
@@ -447,6 +447,41 @@ async def sync_character_equipment(
 
 
 # ---------------------------------------------------------------------------
+# GET /api/v1/items/search?q=
+# Must be registered before /{blizzard_item_id} to avoid "search" matching as an int
+# ---------------------------------------------------------------------------
+
+
+@items_router.get("/search")
+async def search_items(
+    q: str,
+    request: Request,
+    current_player: Player = Depends(get_current_player),
+):
+    """Search cached wow_items by name (ILIKE). Returns up to 10 matches."""
+    if len(q.strip()) < 2:
+        return JSONResponse({"ok": True, "data": []})
+
+    pool = await _get_pool(request)
+    if not pool:
+        return JSONResponse({"ok": False, "error": "Database pool unavailable"}, status_code=503)
+
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT blizzard_item_id, name, icon_url, slot_type
+              FROM guild_identity.wow_items
+             WHERE name ILIKE $1
+             ORDER BY name
+             LIMIT 10
+            """,
+            f"%{q.strip()}%",
+        )
+
+    return JSONResponse({"ok": True, "data": [dict(r) for r in rows]})
+
+
+# ---------------------------------------------------------------------------
 # GET /api/v1/items/{blizzard_item_id}
 # ---------------------------------------------------------------------------
 

--- a/src/guild_portal/services/gear_plan_service.py
+++ b/src/guild_portal/services/gear_plan_service.py
@@ -898,7 +898,7 @@ async def get_plan_detail(
         # Available BIS sources (for UI dropdowns)
         source_list = await conn.fetch(
             """
-            SELECT id, name, short_label, content_type, is_default, sort_order
+            SELECT id, name, short_label, content_type, origin, is_default, sort_order
               FROM guild_identity.bis_list_sources
              WHERE is_active = TRUE
              ORDER BY sort_order

--- a/src/guild_portal/services/gear_plan_service.py
+++ b/src/guild_portal/services/gear_plan_service.py
@@ -905,6 +905,15 @@ async def get_plan_detail(
             """
         )
 
+        # Which sources have hero-talent-specific BIS entries
+        ht_source_ids = await conn.fetchval(
+            """
+            SELECT array_agg(DISTINCT source_id)
+              FROM guild_identity.bis_list_entries
+             WHERE hero_talent_id IS NOT NULL
+            """
+        ) or []
+
         # Hero talents for the plan's spec (for UI dropdown)
         ht_list = []
         if spec_id:
@@ -1084,7 +1093,7 @@ async def get_plan_detail(
     return {
         "plan": dict(plan_row),
         "slots": slots_data,
-        "bis_sources": [dict(r) for r in source_list],
+        "bis_sources": [{**dict(r), "has_hero_talent_variants": r["id"] in ht_source_ids} for r in source_list],
         "hero_talents": ht_list,
         "track_colors": TRACK_COLORS,
     }

--- a/src/guild_portal/services/gear_plan_service.py
+++ b/src/guild_portal/services/gear_plan_service.py
@@ -755,7 +755,7 @@ async def get_plan_detail(
                 SELECT ble.slot, ble.item_id, ble.source_id, ble.hero_talent_id,
                        ble.priority,
                        wi.blizzard_item_id, wi.name AS item_name, wi.icon_url,
-                       bls.name AS source_name, bls.short_label
+                       bls.name AS source_name, bls.short_label, bls.origin, bls.content_type
                   FROM guild_identity.bis_list_entries ble
                   JOIN guild_identity.wow_items wi ON wi.id = ble.item_id
                   JOIN guild_identity.bis_list_sources bls ON bls.id = ble.source_id

--- a/src/guild_portal/static/css/my_characters.css
+++ b/src/guild_portal/static/css/my_characters.css
@@ -894,6 +894,22 @@
   max-width: 64px;
 }
 
+.mcn-bis-grid__provider {
+  font-size: 0.6rem;
+  text-align: center;
+  color: var(--color-text-muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border-bottom: 1px solid rgba(255,255,255,0.06);
+}
+.mcn-bis-grid__provider--solo {
+  font-size: 0.63rem;
+  color: var(--color-text);
+  text-transform: none;
+  letter-spacing: normal;
+  border-bottom: none;
+}
+
 .mcn-bis-grid__check { text-align: center; }
 .mcn-bis-grid__check--yes { color: #4ade80; font-weight: 700; }
 .mcn-bis-grid__check--no  { color: var(--color-text-muted); opacity: 0.4; }

--- a/src/guild_portal/static/css/my_characters.css
+++ b/src/guild_portal/static/css/my_characters.css
@@ -937,9 +937,50 @@
   margin-top: 0.45rem;
 }
 
-.mcn-manual-input {
+.mcn-manual-search-wrap {
+  position: relative;
   flex: 1;
-  max-width: 100px;
+}
+
+.mcn-item-results {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 200;
+  background: #1a1a1e;
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-sm);
+  max-height: 180px;
+  overflow-y: auto;
+  margin-top: 2px;
+}
+
+.mcn-item-result {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.25rem 0.4rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+.mcn-item-result:hover { background: rgba(255,255,255,0.06); }
+
+.mcn-item-result__icon {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+}
+.mcn-item-result__icon-ph {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  display: inline-block;
+}
+
+.mcn-manual-input {
+  width: 100%;
+  max-width: none;
   background: #0d0d0f;
   border: 1px solid var(--color-border-light);
   border-radius: var(--radius-sm);

--- a/src/guild_portal/static/js/my_characters.js
+++ b/src/guild_portal/static/js/my_characters.js
@@ -1626,9 +1626,23 @@ function _gpRenderCenterPanel(data) {
       `<option value="${ht.id}"${plan?.hero_talent_id === ht.id ? ' selected' : ''}>${_gpEsc(ht.name)}</option>`
     )).join('');
 
-  const srcOpts = (bisSources || []).map(s =>
-    `<option value="${s.id}"${plan?.bis_source_id === s.id ? ' selected' : ''}>${_gpEsc(s.name)}</option>`
-  ).join('');
+  const ORIGIN_LABEL      = { archon: 'u.gg', wowhead: 'Wowhead', icy_veins: 'Icy Veins' };
+  const CONTENT_TYPE_LABEL = { raid: 'Raid', mythic_plus: 'M+', overall: 'All' };
+  // Group sources by origin, preserving sort_order within each group
+  const srcByOrigin = [];
+  const seenOrigins = [];
+  for (const s of (bisSources || [])) {
+    if (!seenOrigins.includes(s.origin)) { seenOrigins.push(s.origin); srcByOrigin.push({ origin: s.origin, sources: [] }); }
+    srcByOrigin.find(g => g.origin === s.origin).sources.push(s);
+  }
+  const srcOpts = srcByOrigin.map(({ origin, sources }) => {
+    const groupLabel = ORIGIN_LABEL[origin] || origin;
+    const options = sources.map(s => {
+      const label = (CONTENT_TYPE_LABEL[s.content_type] || s.short_label) + (s.is_default ? ' \u2605' : '');
+      return `<option value="${s.id}"${plan?.bis_source_id === s.id ? ' selected' : ''}>${_gpEsc(label)}</option>`;
+    }).join('');
+    return `<optgroup label="${_gpEsc(groupLabel)}">${options}</optgroup>`;
+  }).join('');
 
   area.innerHTML = `
     <div id="mcn-gp-slot-detail" hidden></div>
@@ -1637,7 +1651,7 @@ function _gpRenderCenterPanel(data) {
       <div class="mcn-gear-ctrl-row">
         <label class="mcn-gear-label">Hero Talent</label>
         <select id="mcn-gp-ht-sel" class="mcn-gear-select">${htOpts}</select>
-        <label class="mcn-gear-label">Source</label>
+        <label class="mcn-gear-label">BIS List</label>
         <select id="mcn-gp-src-sel" class="mcn-gear-select">${srcOpts}</select>
       </div>
       <div class="mcn-gear-actions">

--- a/src/guild_portal/static/js/my_characters.js
+++ b/src/guild_portal/static/js/my_characters.js
@@ -1641,7 +1641,6 @@ function _gpRenderCenterPanel(data) {
         <select id="mcn-gp-src-sel" class="mcn-gear-select">${srcOpts}</select>
       </div>
       <div class="mcn-gear-actions">
-        <button id="mcn-gp-btn-sync"   class="btn btn-secondary btn-sm" type="button">Sync Gear</button>
         <button id="mcn-gp-btn-fill"   class="btn btn-primary btn-sm"   type="button">Fill BIS</button>
         <button id="mcn-gp-btn-import" class="btn btn-secondary btn-sm" type="button">Import SimC</button>
         <button id="mcn-gp-btn-export" class="btn btn-secondary btn-sm" type="button">Export SimC</button>
@@ -1664,7 +1663,6 @@ function _gpRenderCenterPanel(data) {
   // Wire selects + buttons
   document.getElementById('mcn-gp-ht-sel')  ?.addEventListener('change', _gpOnConfigChange);
   document.getElementById('mcn-gp-src-sel') ?.addEventListener('change', _gpOnConfigChange);
-  document.getElementById('mcn-gp-btn-sync')  ?.addEventListener('click', _gpOnSyncGear);
   document.getElementById('mcn-gp-btn-fill')  ?.addEventListener('click', _gpOnPopulate);
   document.getElementById('mcn-gp-btn-import')?.addEventListener('click', _gpShowSimcModal);
   document.getElementById('mcn-gp-btn-export')?.addEventListener('click', _gpOnExportSimc);

--- a/src/guild_portal/static/js/my_characters.js
+++ b/src/guild_portal/static/js/my_characters.js
@@ -1644,7 +1644,6 @@ function _gpRenderCenterPanel(data) {
         <button id="mcn-gp-btn-fill"   class="btn btn-primary btn-sm"   type="button">Fill BIS</button>
         <button id="mcn-gp-btn-import" class="btn btn-secondary btn-sm" type="button">Import SimC</button>
         <button id="mcn-gp-btn-export" class="btn btn-secondary btn-sm" type="button">Export SimC</button>
-        <button id="mcn-gp-btn-reset"  class="btn btn-danger btn-sm"    type="button">Reset Plan</button>
       </div>
     </div>
     <div id="mcn-gp-status" class="mcn-gp-status" hidden></div>
@@ -1666,7 +1665,6 @@ function _gpRenderCenterPanel(data) {
   document.getElementById('mcn-gp-btn-fill')  ?.addEventListener('click', _gpOnPopulate);
   document.getElementById('mcn-gp-btn-import')?.addEventListener('click', _gpShowSimcModal);
   document.getElementById('mcn-gp-btn-export')?.addEventListener('click', _gpOnExportSimc);
-  document.getElementById('mcn-gp-btn-reset') ?.addEventListener('click', _gpOnDeletePlan);
 
   // Wire SimC modal once
   const modal = document.getElementById('mcn-simc-modal');

--- a/src/guild_portal/static/js/my_characters.js
+++ b/src/guild_portal/static/js/my_characters.js
@@ -2068,11 +2068,52 @@ function _gpRenderBisGrid(slotKey, bis, tc, primaryBid, dbSlot) {
   dbSlot = dbSlot || slotKey;
   if (!bis.length) return '<div class="mcn-drawer-empty">No BIS data for this slot</div>';
 
+  const ORIGIN_LABEL_G       = { archon: 'u.gg', wowhead: 'Wowhead', icy_veins: 'Icy Veins' };
+  const CONTENT_TYPE_LABEL_G = { raid: 'Raid', mythic_plus: 'M+', overall: 'All' };
+
   const srcMap = new Map();
   for (const r of bis) {
-    if (!srcMap.has(r.source_id)) srcMap.set(r.source_id, r.short_label || r.source_name || `Source ${r.source_id}`);
+    if (!srcMap.has(r.source_id)) srcMap.set(r.source_id, {
+      id: r.source_id,
+      label: r.short_label || r.source_name || `Source ${r.source_id}`,
+      origin: r.origin || '',
+      content_type: r.content_type || '',
+    });
   }
-  const sources = [...srcMap.entries()].map(([id, label]) => ({ id, label }));
+  const sources = [...srcMap.values()];
+
+  // Group sources by origin for two-row header
+  const originGroups = [];
+  const seenOrigins  = [];
+  for (const s of sources) {
+    if (!seenOrigins.includes(s.origin)) { seenOrigins.push(s.origin); originGroups.push({ origin: s.origin, cols: [] }); }
+    originGroups.find(g => g.origin === s.origin).cols.push(s);
+  }
+  const hasMultiColGroup = originGroups.some(g => g.cols.length > 1);
+
+  // Row 1: "Item" + provider cells + action
+  const providerCells = originGroups.map(g => {
+    const label   = _gpEsc(ORIGIN_LABEL_G[g.origin] || g.origin);
+    const colspan = g.cols.length;
+    // Single-column group: span both rows so row 2 stays clean
+    return colspan === 1
+      ? `<th class="mcn-bis-grid__provider mcn-bis-grid__provider--solo"${hasMultiColGroup ? ' rowspan="2"' : ''}>${label}</th>`
+      : `<th class="mcn-bis-grid__provider" colspan="${colspan}">${label}</th>`;
+  }).join('');
+
+  // Row 2: content-type label for each column in multi-col groups only
+  const contentCells = hasMultiColGroup
+    ? originGroups.flatMap(g => g.cols.length === 1 ? [] : g.cols.map(s =>
+        `<th class="mcn-bis-grid__src">${_gpEsc(CONTENT_TYPE_LABEL_G[s.content_type] || s.label)}</th>`
+      )).join('')
+    : '';
+
+  const thead = hasMultiColGroup
+    ? `<thead>
+        <tr><th class="mcn-bis-grid__name-col" rowspan="2">Item</th>${providerCells}<th rowspan="2"></th></tr>
+        <tr>${contentCells}</tr>
+       </thead>`
+    : `<thead><tr><th class="mcn-bis-grid__name-col">Item</th>${providerCells}<th></th></tr></thead>`;
 
   const itemMap = new Map();
   for (const r of bis) {
@@ -2088,8 +2129,6 @@ function _gpRenderBisGrid(slotKey, bis, tc, primaryBid, dbSlot) {
     const d2 = b.srcIds.size - a.srcIds.size;
     return d2 !== 0 ? d2 : a.name.localeCompare(b.name);
   });
-
-  const hdrCells = sources.map(s => `<th class="mcn-bis-grid__src" title="${_gpEsc(s.label)}">${_gpEsc(s.label)}</th>`).join('');
 
   const rows = items.map(item => {
     const cells = sources.map(s =>
@@ -2107,10 +2146,7 @@ function _gpRenderBisGrid(slotKey, bis, tc, primaryBid, dbSlot) {
     </tr>`;
   }).join('');
 
-  return `<table class="mcn-bis-grid">
-    <thead><tr><th class="mcn-bis-grid__name-col">Item</th>${hdrCells}<th></th></tr></thead>
-    <tbody>${rows}</tbody>
-  </table>`;
+  return `<table class="mcn-bis-grid">${thead}<tbody>${rows}</tbody></table>`;
 }
 
 // ── Slot action globals (called from onclick attrs in drawer) ──────────────────

--- a/src/guild_portal/static/js/my_characters.js
+++ b/src/guild_portal/static/js/my_characters.js
@@ -1631,13 +1631,16 @@ function _gpRenderCenterPanel(data) {
 
   const ORIGIN_LABEL      = { archon: 'u.gg', wowhead: 'Wowhead', icy_veins: 'Icy Veins' };
   const CONTENT_TYPE_LABEL = { raid: 'Raid', mythic_plus: 'M+', overall: 'All' };
-  // Group sources by origin, preserving sort_order within each group
+  const CONTENT_TYPE_ORDER = { overall: 0, raid: 1, mythic_plus: 2 };
+  // Group sources by origin; within each group put All first
   const srcByOrigin = [];
   const seenOrigins = [];
   for (const s of (bisSources || [])) {
     if (!seenOrigins.includes(s.origin)) { seenOrigins.push(s.origin); srcByOrigin.push({ origin: s.origin, sources: [] }); }
     srcByOrigin.find(g => g.origin === s.origin).sources.push(s);
   }
+  srcByOrigin.forEach(g => g.sources.sort((a, b) =>
+    (CONTENT_TYPE_ORDER[a.content_type] ?? 9) - (CONTENT_TYPE_ORDER[b.content_type] ?? 9)));
   const srcOpts = srcByOrigin.map(({ origin, sources }) => {
     const groupLabel = ORIGIN_LABEL[origin] || origin;
     const options = sources.map(s => {
@@ -2068,8 +2071,9 @@ function _gpRenderBisGrid(slotKey, bis, tc, primaryBid, dbSlot) {
   dbSlot = dbSlot || slotKey;
   if (!bis.length) return '<div class="mcn-drawer-empty">No BIS data for this slot</div>';
 
-  const ORIGIN_LABEL_G       = { archon: 'u.gg', wowhead: 'Wowhead', icy_veins: 'Icy Veins' };
-  const CONTENT_TYPE_LABEL_G = { raid: 'Raid', mythic_plus: 'M+', overall: 'All' };
+  const ORIGIN_LABEL_G        = { archon: 'u.gg', wowhead: 'Wowhead', icy_veins: 'Icy Veins' };
+  const CONTENT_TYPE_LABEL_G  = { raid: 'Raid', mythic_plus: 'M+', overall: 'All' };
+  const CONTENT_TYPE_ORDER_G  = { overall: 0, raid: 1, mythic_plus: 2 };
 
   const srcMap = new Map();
   for (const r of bis) {
@@ -2089,6 +2093,8 @@ function _gpRenderBisGrid(slotKey, bis, tc, primaryBid, dbSlot) {
     if (!seenOrigins.includes(s.origin)) { seenOrigins.push(s.origin); originGroups.push({ origin: s.origin, cols: [] }); }
     originGroups.find(g => g.origin === s.origin).cols.push(s);
   }
+  originGroups.forEach(g => g.cols.sort((a, b) =>
+    (CONTENT_TYPE_ORDER_G[a.content_type] ?? 9) - (CONTENT_TYPE_ORDER_G[b.content_type] ?? 9)));
   const hasMultiColGroup = originGroups.some(g => g.cols.length > 1);
 
   // Row 1: "Item" + provider cells + action

--- a/src/guild_portal/static/js/my_characters.js
+++ b/src/guild_portal/static/js/my_characters.js
@@ -1643,8 +1643,8 @@ function _gpRenderCenterPanel(data) {
       <div class="mcn-gear-actions">
         <button id="mcn-gp-btn-fill"   class="btn btn-primary btn-sm"   type="button">Fill BIS</button>
         <!-- SimC hidden pending full testing — see reference/gear-plan-4-simc.md -->
-        <button id="mcn-gp-btn-import" class="btn btn-secondary btn-sm" type="button" hidden>Import SimC</button>
-        <button id="mcn-gp-btn-export" class="btn btn-secondary btn-sm" type="button" hidden>Export SimC</button>
+        <button id="mcn-gp-btn-import" class="btn btn-secondary btn-sm" type="button" style="display:none">Import SimC</button>
+        <button id="mcn-gp-btn-export" class="btn btn-secondary btn-sm" type="button" style="display:none">Export SimC</button>
       </div>
     </div>
     <div id="mcn-gp-status" class="mcn-gp-status" hidden></div>

--- a/src/guild_portal/static/js/my_characters.js
+++ b/src/guild_portal/static/js/my_characters.js
@@ -1642,8 +1642,9 @@ function _gpRenderCenterPanel(data) {
       </div>
       <div class="mcn-gear-actions">
         <button id="mcn-gp-btn-fill"   class="btn btn-primary btn-sm"   type="button">Fill BIS</button>
-        <button id="mcn-gp-btn-import" class="btn btn-secondary btn-sm" type="button">Import SimC</button>
-        <button id="mcn-gp-btn-export" class="btn btn-secondary btn-sm" type="button">Export SimC</button>
+        <!-- SimC hidden pending full testing — see reference/gear-plan-4-simc.md -->
+        <button id="mcn-gp-btn-import" class="btn btn-secondary btn-sm" type="button" hidden>Import SimC</button>
+        <button id="mcn-gp-btn-export" class="btn btn-secondary btn-sm" type="button" hidden>Export SimC</button>
       </div>
     </div>
     <div id="mcn-gp-status" class="mcn-gp-status" hidden></div>
@@ -1663,19 +1664,6 @@ function _gpRenderCenterPanel(data) {
   document.getElementById('mcn-gp-ht-sel')  ?.addEventListener('change', _gpOnConfigChange);
   document.getElementById('mcn-gp-src-sel') ?.addEventListener('change', _gpOnConfigChange);
   document.getElementById('mcn-gp-btn-fill')  ?.addEventListener('click', _gpOnPopulate);
-  document.getElementById('mcn-gp-btn-import')?.addEventListener('click', _gpShowSimcModal);
-  document.getElementById('mcn-gp-btn-export')?.addEventListener('click', _gpOnExportSimc);
-
-  // Wire SimC modal once
-  const modal = document.getElementById('mcn-simc-modal');
-  if (modal && !modal._gpWired) {
-    modal._gpWired = true;
-    document.getElementById('mcn-simc-close') ?.addEventListener('click', _gpHideSimcModal);
-    document.getElementById('mcn-simc-cancel')?.addEventListener('click', _gpHideSimcModal);
-    document.getElementById('mcn-simc-submit')?.addEventListener('click', _gpOnSimcImport);
-    modal.querySelector('.mcn-modal__backdrop')?.addEventListener('click', _gpHideSimcModal);
-  }
-
   // Wire drawer close
   const drawerClose = document.getElementById('mcn-gp-drawer-close');
   if (drawerClose && !drawerClose._gpWired) {

--- a/src/guild_portal/static/js/my_characters.js
+++ b/src/guild_portal/static/js/my_characters.js
@@ -1621,6 +1621,9 @@ function _gpRenderCenterPanel(data) {
   const bisSources  = data.bis_sources  || [];
   const heroTalents = data.hero_talents || [];
 
+  const selectedSource = bisSources.find(s => s.id === plan?.bis_source_id) || bisSources[0];
+  const showHtDropdown = !!(selectedSource?.has_hero_talent_variants && heroTalents.length > 0);
+
   const htOpts = ['<option value="">\u2014 Any \u2014</option>']
     .concat((heroTalents || []).map(ht =>
       `<option value="${ht.id}"${plan?.hero_talent_id === ht.id ? ' selected' : ''}>${_gpEsc(ht.name)}</option>`
@@ -1649,10 +1652,11 @@ function _gpRenderCenterPanel(data) {
     <div class="mcn-detail-area__heading">Gear Plan</div>
     <div class="mcn-gear-controls">
       <div class="mcn-gear-ctrl-row">
-        <label class="mcn-gear-label">Hero Talent</label>
-        <select id="mcn-gp-ht-sel" class="mcn-gear-select">${htOpts}</select>
         <label class="mcn-gear-label">BIS List</label>
         <select id="mcn-gp-src-sel" class="mcn-gear-select">${srcOpts}</select>
+        ${showHtDropdown ? `
+        <label class="mcn-gear-label">Hero Talent</label>
+        <select id="mcn-gp-ht-sel" class="mcn-gear-select">${htOpts}</select>` : ''}
       </div>
       <div class="mcn-gear-actions">
         <button id="mcn-gp-btn-fill"   class="btn btn-primary btn-sm"   type="button">Fill BIS</button>

--- a/src/guild_portal/static/js/my_characters.js
+++ b/src/guild_portal/static/js/my_characters.js
@@ -2008,7 +2008,13 @@ function _gpRenderDrawerBody(slotKey, sd, tc) {
   }
 
   const manualHtml = `<div class="mcn-manual-row">
-    <input type="number" class="mcn-manual-input" id="mcn-mid-${_gpEsc(dbSlot)}" placeholder="Item ID" min="1">
+    <div class="mcn-manual-search-wrap">
+      <input type="text" class="mcn-manual-input" id="mcn-mid-${_gpEsc(dbSlot)}"
+             placeholder="Name, ID, or Wowhead link"
+             oninput="mcnGpSearchItems('${_gpEsc(dbSlot)}', this.value)"
+             autocomplete="off">
+      <div class="mcn-item-results" id="mcn-mir-${_gpEsc(dbSlot)}" hidden></div>
+    </div>
     <button class="btn btn-sm btn-secondary" type="button" onclick="mcnGpFetchAndSet('${_gpEsc(dbSlot)}')">Fetch</button>
   </div>`;
 
@@ -2195,11 +2201,67 @@ window.mcnGpToggleLock = async function(slot, currentlyLocked) {
 };
 
 window.mcnGpFetchAndSet = async function(slot) {
-  const input  = document.getElementById(`mcn-mid-${slot}`);
-  const itemId = parseInt(input?.value, 10);
-  if (!itemId) return;
-  _gpShowStatus('Fetching item\u2026', 'info');
-  const itemResp = await _gpFetch(`/api/v1/items/${itemId}`);
-  if (!itemResp.ok) { _gpShowStatus(itemResp.error || 'Item not found', 'err'); return; }
-  await window.mcnGpSetDesiredItem(slot, itemResp.data.blizzard_item_id);
+  const input = document.getElementById(`mcn-mid-${slot}`);
+  const raw   = input?.value?.trim() || '';
+  if (!raw) return;
+
+  // Format 2 — Wowhead URL: extract item ID from /item=NNNNN or /item/NNNNN
+  const urlMatch = raw.match(/[?&/]item[=/](\d+)/i);
+  if (urlMatch) {
+    const itemId = parseInt(urlMatch[1], 10);
+    _gpShowStatus('Fetching item\u2026', 'info');
+    const itemResp = await _gpFetch(`/api/v1/items/${itemId}`);
+    if (!itemResp.ok) { _gpShowStatus(itemResp.error || 'Item not found', 'err'); return; }
+    await window.mcnGpSetDesiredItem(slot, itemResp.data.blizzard_item_id);
+    return;
+  }
+
+  // Format 1 — Plain integer
+  const itemId = parseInt(raw, 10);
+  if (!isNaN(itemId) && itemId > 0 && String(itemId) === raw) {
+    _gpShowStatus('Fetching item\u2026', 'info');
+    const itemResp = await _gpFetch(`/api/v1/items/${itemId}`);
+    if (!itemResp.ok) { _gpShowStatus(itemResp.error || 'Item not found', 'err'); return; }
+    await window.mcnGpSetDesiredItem(slot, itemResp.data.blizzard_item_id);
+    return;
+  }
+
+  // Format 3 — Name: trigger inline search
+  await window.mcnGpSearchItems(slot, raw);
+};
+
+window.mcnGpSearchItems = async function(slot, value) {
+  const val       = (value || '').trim();
+  const resultsEl = document.getElementById(`mcn-mir-${slot}`);
+  if (!resultsEl) return;
+
+  // Don't search for plain numbers or URLs — those go through Fetch
+  if (val.length < 2 || /^\d+$/.test(val) || /[?&/]item[=/]/i.test(val)) {
+    resultsEl.hidden = true;
+    resultsEl.innerHTML = '';
+    return;
+  }
+
+  const resp = await _gpFetch(`/api/v1/items/search?q=${encodeURIComponent(val)}`);
+  if (!resp.ok || !resp.data?.length) {
+    resultsEl.hidden = true;
+    resultsEl.innerHTML = '';
+    return;
+  }
+
+  resultsEl.innerHTML = resp.data.map(item => {
+    const icon = item.icon_url
+      ? `<img src="${_gpEsc(item.icon_url)}" alt="" class="mcn-item-result__icon">`
+      : `<span class="mcn-item-result__icon-ph"></span>`;
+    return `<div class="mcn-item-result" onclick="mcnGpPickSearchResult('${_gpEsc(slot)}',${item.blizzard_item_id},'${_gpEsc(item.name)}')">${icon}<span>${_gpEsc(item.name)}</span></div>`;
+  }).join('');
+  resultsEl.hidden = false;
+};
+
+window.mcnGpPickSearchResult = async function(slot, blizzardItemId, name) {
+  const resultsEl = document.getElementById(`mcn-mir-${slot}`);
+  if (resultsEl) { resultsEl.hidden = true; resultsEl.innerHTML = ''; }
+  const input = document.getElementById(`mcn-mid-${slot}`);
+  if (input) input.value = '';
+  await window.mcnGpSetDesiredItem(slot, blizzardItemId);
 };

--- a/src/guild_portal/templates/member/my_characters.html
+++ b/src/guild_portal/templates/member/my_characters.html
@@ -2,7 +2,7 @@
 {% block title %}My Characters — {{ site().guild_name }}{% endblock %}
 
 {% block head %}
-<link rel="stylesheet" href="/static/css/my_characters.css?v=1.1.0">
+<link rel="stylesheet" href="/static/css/my_characters.css?v=1.2.0">
 {% endblock %}
 
 {% block content %}
@@ -156,5 +156,5 @@
 {% block scripts %}
 <script>var whTooltips = {colorLinks: true, iconizeLinks: false, renameLinks: false, hide: {sellprice: true, ilvl: false, reqlevel: false, power: false}};</script>
 <script src="https://wow.zamimg.com/widgets/power.js"></script>
-<script src="/static/js/my_characters.js?v=1.4.1"></script>
+<script src="/static/js/my_characters.js?v=1.5.0"></script>
 {% endblock %}

--- a/src/guild_portal/templates/member/my_characters.html
+++ b/src/guild_portal/templates/member/my_characters.html
@@ -156,5 +156,5 @@
 {% block scripts %}
 <script>var whTooltips = {colorLinks: true, iconizeLinks: false, renameLinks: false, hide: {sellprice: true, ilvl: false, reqlevel: false, power: false}};</script>
 <script src="https://wow.zamimg.com/widgets/power.js"></script>
-<script src="/static/js/my_characters.js"></script>
+<script src="/static/js/my_characters.js?v=1.1.0"></script>
 {% endblock %}

--- a/src/guild_portal/templates/member/my_characters.html
+++ b/src/guild_portal/templates/member/my_characters.html
@@ -126,6 +126,7 @@
 </div>{# end .mcn-page #}
 
 {# ── SimC Import Modal — Phase UI-1C ─────────────────────────────────────── #}
+{# SimC hidden pending full testing — see reference/gear-plan-4-simc.md
 <div id="mcn-simc-modal" class="mcn-modal" hidden>
   <div class="mcn-modal__backdrop"></div>
   <div class="mcn-modal__box">
@@ -149,6 +150,7 @@
     </div>
   </div>
 </div>
+#}
 {% endblock %}
 
 {% block scripts %}

--- a/src/guild_portal/templates/member/my_characters.html
+++ b/src/guild_portal/templates/member/my_characters.html
@@ -156,5 +156,5 @@
 {% block scripts %}
 <script>var whTooltips = {colorLinks: true, iconizeLinks: false, renameLinks: false, hide: {sellprice: true, ilvl: false, reqlevel: false, power: false}};</script>
 <script src="https://wow.zamimg.com/widgets/power.js"></script>
-<script src="/static/js/my_characters.js?v=1.1.0"></script>
+<script src="/static/js/my_characters.js?v=1.2.0"></script>
 {% endblock %}

--- a/src/guild_portal/templates/member/my_characters.html
+++ b/src/guild_portal/templates/member/my_characters.html
@@ -2,7 +2,7 @@
 {% block title %}My Characters — {{ site().guild_name }}{% endblock %}
 
 {% block head %}
-<link rel="stylesheet" href="/static/css/my_characters.css">
+<link rel="stylesheet" href="/static/css/my_characters.css?v=1.1.0">
 {% endblock %}
 
 {% block content %}
@@ -156,5 +156,5 @@
 {% block scripts %}
 <script>var whTooltips = {colorLinks: true, iconizeLinks: false, renameLinks: false, hide: {sellprice: true, ilvl: false, reqlevel: false, power: false}};</script>
 <script src="https://wow.zamimg.com/widgets/power.js"></script>
-<script src="/static/js/my_characters.js?v=1.3.0"></script>
+<script src="/static/js/my_characters.js?v=1.4.0"></script>
 {% endblock %}

--- a/src/guild_portal/templates/member/my_characters.html
+++ b/src/guild_portal/templates/member/my_characters.html
@@ -156,5 +156,5 @@
 {% block scripts %}
 <script>var whTooltips = {colorLinks: true, iconizeLinks: false, renameLinks: false, hide: {sellprice: true, ilvl: false, reqlevel: false, power: false}};</script>
 <script src="https://wow.zamimg.com/widgets/power.js"></script>
-<script src="/static/js/my_characters.js?v=1.2.0"></script>
+<script src="/static/js/my_characters.js?v=1.3.0"></script>
 {% endblock %}

--- a/src/guild_portal/templates/member/my_characters.html
+++ b/src/guild_portal/templates/member/my_characters.html
@@ -156,5 +156,5 @@
 {% block scripts %}
 <script>var whTooltips = {colorLinks: true, iconizeLinks: false, renameLinks: false, hide: {sellprice: true, ilvl: false, reqlevel: false, power: false}};</script>
 <script src="https://wow.zamimg.com/widgets/power.js"></script>
-<script src="/static/js/my_characters.js?v=1.4.0"></script>
+<script src="/static/js/my_characters.js?v=1.4.1"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary

- **Remove Sync Gear button** — redundant with top-right Refresh; endpoint stays intact
- **Remove Reset Plan button** — no use case distinct from Fill BIS; endpoint stays intact
- **Hide SimC buttons** — commented out pending full testing (see `reference/gear-plan-4-simc.md`); all backend intact
- **BIS List source dropdown** — grouped by provider (`<optgroup>`), content type labels (All/Raid/M+) with ★ on default, ordered All first within each group
- **Hero Talent dropdown** — conditional: only shown when selected source has HT-specific BIS entries (`has_hero_talent_variants` flag from `gear_plan_service`)
- **BIS grid two-row header** — provider row (u.gg / Wowhead / Icy Veins) with colspan; content type row (All / Raid / M+) below; single-source providers use rowspan=2
- **Item lookup** — input now accepts plain ID, Wowhead URL (extracts `/item=ID`), or item name (live search via new `GET /api/v1/items/search?q=` endpoint with inline dropdown)

No migrations.

## Test plan

- [ ] Gear tab controls row: BIS List dropdown + conditional HT dropdown + Fill BIS only
- [ ] Source dropdown shows optgroups (u.gg / Wowhead / Icy Veins), All ★ first in each group
- [ ] Switching to Wowhead/Icy Veins source hides the HT dropdown; switching back to u.gg shows it
- [ ] Slot drawer BIS grid shows two-row header with provider row and content type row
- [ ] Slot drawer item input: paste Wowhead URL → sets item; type integer → sets item; type name → inline dropdown appears, click sets item

🤖 Generated with [Claude Code](https://claude.com/claude-code)