### PR TITLE
feat: Phase 1E.5 — item exclusion per gear plan slot

### DIFF
--- a/alembic/versions/0093_gear_plan_slots_excluded_item_ids.py
+++ b/alembic/versions/0093_gear_plan_slots_excluded_item_ids.py
@@ -1,0 +1,29 @@
+"""Add excluded_item_ids to guild_identity.gear_plan_slots for Phase 1E.5.
+
+Lets players permanently exclude specific items per slot so Fill BIS skips them,
+BIS recommendations omit them, and the Available from Content list hides them.
+
+Revision ID: 0093
+Revises: 0092
+"""
+
+from alembic import op
+
+revision = "0093"
+down_revision = "0092"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""
+        ALTER TABLE guild_identity.gear_plan_slots
+        ADD COLUMN IF NOT EXISTS excluded_item_ids INTEGER[] NOT NULL DEFAULT '{}'
+    """)
+
+
+def downgrade():
+    op.execute("""
+        ALTER TABLE guild_identity.gear_plan_slots
+        DROP COLUMN IF EXISTS excluded_item_ids
+    """)

--- a/reference/gear-plan-1-feature.md
+++ b/reference/gear-plan-1-feature.md
@@ -32,12 +32,12 @@ The guild needs to answer "what should we run this week?" from a loot perspectiv
 | **1E.2** Roster aggregation — drill panel | ✅ DONE | Slide-in panel; By Item + By Player spoke-list views; Wowhead tooltips; active chip highlight |
 | **1E.3** Roster aggregation — auto-setup new members | ✅ DONE | `gear_plan_auto_setup.py` in sv_common/guild_sync; called from `_sync_one_character` after equipment commit; no-op if plan exists or no player link |
 | **1E.4** Class-eligible items in slot table | ✅ DONE | `get_available_items()` in gear_plan_service + `GET /api/v1/me/gear-plan/{character_id}/available-items?slot=`. CLASS_ARMOR_TYPE + SPEC_PRIMARY_STAT static maps; armor slots filter by class armor_type; weapon slots filter by primary stat via tooltip substring check; accessories unrestricted. Frontend: collapsible `<details>` section in slot drawer with lazy fetch + in-place update; _gpAvailCache per-char/slot; cache cleared on _gpReload(). |
-| **1E.5** Item exclusion | ⬜ TODO | `excluded_item_ids INTEGER[]` on `gear_plan_slots` (migration); Fill BIS + BIS recommendations skip excluded items; ✕ button per item row in slot drawer |
+| **1E.5** Item exclusion | ✅ DONE | `excluded_item_ids INTEGER[]` on `gear_plan_slots` (migration 0093); Fill BIS skips excluded items (tries next priority candidate); BIS recommendations filter per-slot; Available from Content hides excluded items; ✕ button on every BIS/available row; 3-second undo toast; collapsed "Excluded items" ↩ section at bottom of drawer. PATCH/DELETE `/api/v1/me/gear-plan/{character_id}/slots/{slot}/exclude`. |
 | **1E.6** SimC as gear source + freshness indicator | ⬜ TODO | Parse stored `simc_profile` for item IDs + bonus IDs; `simc_imported_at` timestamp (migration); source toggle (Blizzard API / SimC Import) on paperdoll with timestamps; staleness warning if SimC >7 days; guild roster metrics always use Blizzard API |
 | **1E.7** Help system — guided tour + FAQ | ⬜ TODO | Shepherd.js overlay tour triggered by ? button (auto-fires on first visit via localStorage); collapsible FAQ accordion at bottom of gear plan tab including SimC addon tutorial and "Where did this plan come from?" |
 
-**Active branch:** `main`
-**Last migration:** 0092
+**Active branch:** `feature/gear-plan-phase-1e5`
+**Last migration:** 0093
 **Last prod tag:** `prod-v0.14.0`
 
 ---

--- a/src/guild_portal/api/gear_plan_routes.py
+++ b/src/guild_portal/api/gear_plan_routes.py
@@ -316,6 +316,91 @@ async def get_available_items(
 
 
 # ---------------------------------------------------------------------------
+# PATCH /api/v1/me/gear-plan/{character_id}/slots/{slot}/exclude
+# DELETE /api/v1/me/gear-plan/{character_id}/slots/{slot}/exclude
+# Phase 1E.5 — item exclusion
+# ---------------------------------------------------------------------------
+
+
+@router.patch("/{character_id}/slots/{slot}/exclude")
+async def add_item_exclusion(
+    character_id: int,
+    slot: str,
+    request: Request,
+    current_player: Player = Depends(get_current_player),
+    db: AsyncSession = Depends(get_db),
+):
+    """Permanently exclude an item from a slot's suggestions and Fill BIS.
+
+    Body:
+        blizzard_item_id (int)
+    """
+    if slot not in svc.WOW_SLOTS:
+        return JSONResponse({"ok": False, "error": f"Unknown slot: {slot}"}, status_code=400)
+
+    if not await _verify_ownership(current_player, character_id, db):
+        return JSONResponse({"ok": False, "error": "Character not linked to your account"}, status_code=403)
+
+    pool = await _get_pool(request)
+    if not pool:
+        return JSONResponse({"ok": False, "error": "Database pool unavailable"}, status_code=503)
+
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"ok": False, "error": "Invalid JSON"}, status_code=400)
+
+    blizzard_item_id: Optional[int] = body.get("blizzard_item_id")
+    if not blizzard_item_id:
+        return JSONResponse({"ok": False, "error": "blizzard_item_id is required"}, status_code=400)
+
+    ok = await svc.add_exclusion(pool, current_player.id, character_id, slot, blizzard_item_id)
+    if not ok:
+        return JSONResponse({"ok": False, "error": "Plan or item not found"}, status_code=404)
+
+    return JSONResponse({"ok": True})
+
+
+@router.delete("/{character_id}/slots/{slot}/exclude")
+async def remove_item_exclusion(
+    character_id: int,
+    slot: str,
+    request: Request,
+    current_player: Player = Depends(get_current_player),
+    db: AsyncSession = Depends(get_db),
+):
+    """Un-exclude a previously excluded item from a slot.
+
+    Body:
+        blizzard_item_id (int)
+    """
+    if slot not in svc.WOW_SLOTS:
+        return JSONResponse({"ok": False, "error": f"Unknown slot: {slot}"}, status_code=400)
+
+    if not await _verify_ownership(current_player, character_id, db):
+        return JSONResponse({"ok": False, "error": "Character not linked to your account"}, status_code=403)
+
+    pool = await _get_pool(request)
+    if not pool:
+        return JSONResponse({"ok": False, "error": "Database pool unavailable"}, status_code=503)
+
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"ok": False, "error": "Invalid JSON"}, status_code=400)
+
+    blizzard_item_id: Optional[int] = body.get("blizzard_item_id")
+    if not blizzard_item_id:
+        return JSONResponse({"ok": False, "error": "blizzard_item_id is required"}, status_code=400)
+
+    ok = await svc.remove_exclusion(pool, current_player.id, character_id, slot, blizzard_item_id)
+    if not ok:
+        return JSONResponse({"ok": False, "error": "Plan not found"}, status_code=404)
+
+    return JSONResponse({"ok": True})
+
+
+# ---------------------------------------------------------------------------
 # POST /api/v1/me/gear-plan/{character_id}/import-simc
 # ---------------------------------------------------------------------------
 

--- a/src/guild_portal/services/gear_plan_service.py
+++ b/src/guild_portal/services/gear_plan_service.py
@@ -505,17 +505,25 @@ async def populate_from_bis(
         if not spec_id or not use_source:
             return 0
 
-        # Find current locked slots
-        locked_slots_rows = await conn.fetch(
-            "SELECT slot FROM guild_identity.gear_plan_slots WHERE plan_id=$1 AND is_locked=TRUE",
+        # Load current slot state: locked flags and per-slot exclusions (Phase 1E.5)
+        slot_data_rows = await conn.fetch(
+            """
+            SELECT slot, is_locked, excluded_item_ids
+              FROM guild_identity.gear_plan_slots
+             WHERE plan_id = $1
+            """,
             plan_id,
         )
-        locked_slots = {r["slot"] for r in locked_slots_rows}
+        locked_slots: set[str] = {r["slot"] for r in slot_data_rows if r["is_locked"]}
+        excluded_by_slot: dict[str, set[int]] = {
+            r["slot"]: set(r["excluded_item_ids"] or []) for r in slot_data_rows
+        }
 
-        # Get BIS entries (first priority per slot)
+        # Get ALL BIS entries ordered by priority so we can skip excluded items
+        # and fall through to the next-best candidate per slot.
         bis_rows = await conn.fetch(
             """
-            SELECT DISTINCT ON (ble.slot) ble.slot, ble.item_id, ble.priority,
+            SELECT ble.slot, ble.item_id, ble.priority,
                    wi.blizzard_item_id, wi.name AS item_name
               FROM guild_identity.bis_list_entries ble
               JOIN guild_identity.wow_items wi ON wi.id = ble.item_id
@@ -527,12 +535,21 @@ async def populate_from_bis(
             use_source, spec_id, use_ht,
         )
 
-        populated = 0
+        # Group candidates by slot (already ordered by priority)
+        by_slot: dict[str, list] = {}
         for row in bis_rows:
-            slot = row["slot"]
-            if slot not in WOW_SLOTS:
+            by_slot.setdefault(row["slot"], []).append(row)
+
+        populated = 0
+        for slot, candidates in by_slot.items():
+            if slot not in WOW_SLOTS or slot in locked_slots:
                 continue
-            if slot in locked_slots:
+            # Skip excluded items, pick first non-excluded candidate
+            excluded = excluded_by_slot.get(slot, set())
+            chosen = next(
+                (r for r in candidates if r["item_id"] not in excluded), None
+            )
+            if not chosen:
                 continue
 
             await conn.execute(
@@ -546,7 +563,7 @@ async def populate_from_bis(
                         item_name        = EXCLUDED.item_name
                     WHERE gear_plan_slots.is_locked = FALSE
                 """,
-                plan_id, slot, row["item_id"], row["blizzard_item_id"], row["item_name"],
+                plan_id, slot, chosen["item_id"], chosen["blizzard_item_id"], chosen["item_name"],
             )
             populated += 1
 
@@ -774,12 +791,13 @@ async def get_plan_detail(
                     "is_crafted": is_crafted_item(_bonus_ids),
                 }
 
-        # Desired items (plan slots)
+        # Desired items (plan slots) — include excluded_item_ids for Phase 1E.5
         desired_rows = await conn.fetch(
             """
             SELECT gps.slot, gps.blizzard_item_id,
                    COALESCE(wi.name, gps.item_name) AS item_name,
                    gps.is_locked,
+                   gps.excluded_item_ids,
                    wi.icon_url, wi.wowhead_tooltip_html
               FROM guild_identity.gear_plan_slots gps
               LEFT JOIN guild_identity.wow_items wi ON wi.id = gps.desired_item_id
@@ -796,6 +814,7 @@ async def get_plan_detail(
         craftable_desired_bids: set[int] = set()
         tier_piece_desired_bids: set[int] = set()
         desired_by_slot: dict[str, dict] = {}
+        excluded_ids_by_slot: dict[str, list[int]] = {}
         for r in desired_rows:
             bid = r["blizzard_item_id"]
             tooltip = r["wowhead_tooltip_html"] or ""
@@ -805,6 +824,23 @@ async def get_plan_detail(
                 tier_piece_desired_bids.add(bid)
             row_dict = {k: v for k, v in dict(r).items() if k != "wowhead_tooltip_html"}
             desired_by_slot[r["slot"]] = row_dict
+            excluded_ids_by_slot[r["slot"]] = list(r["excluded_item_ids"] or [])
+
+        # Batch-fetch info for all excluded wow_items so the drawer can show names/icons
+        all_excluded_ids: list[int] = [
+            id_ for ids in excluded_ids_by_slot.values() for id_ in ids
+        ]
+        excluded_item_info: dict[int, dict] = {}
+        if all_excluded_ids:
+            ex_rows = await conn.fetch(
+                """
+                SELECT id, blizzard_item_id, name, icon_url
+                  FROM guild_identity.wow_items
+                 WHERE id = ANY($1::int[])
+                """,
+                all_excluded_ids,
+            )
+            excluded_item_info = {r["id"]: dict(r) for r in ex_rows}
 
         # BIS recommendations for this spec + hero_talent
         bis_by_slot: dict[str, list[dict]] = {}
@@ -1051,7 +1087,19 @@ async def get_plan_detail(
     for slot in WOW_SLOTS:
         equipped = equipped_by_slot.get(slot)
         desired = desired_by_slot.get(slot)
-        bis_recs = bis_by_slot.get(slot, [])
+
+        # Phase 1E.5: per-slot exclusions filter BIS recommendations
+        excluded_ids = excluded_ids_by_slot.get(slot, [])
+        excluded_set = set(excluded_ids)
+        excluded_items = [
+            excluded_item_info[id_]
+            for id_ in excluded_ids
+            if id_ in excluded_item_info
+        ]
+        bis_recs = [
+            r for r in bis_by_slot.get(slot, [])
+            if r["item_id"] not in excluded_set
+        ]
 
         # Effective desired blizzard_item_id — only from explicit gear_plan_slots.
         # We deliberately do NOT fall back to BIS recommendations here: for paired
@@ -1147,6 +1195,8 @@ async def get_plan_detail(
             "is_bis": is_bis,
             "needs_upgrade": needs_upgrade,
             "crafted_source": crafted_source,
+            "excluded_item_ids": excluded_ids,
+            "excluded_items": excluded_items,
         }
 
     return {
@@ -1197,6 +1247,7 @@ async def get_available_items(
     Used to populate the 'Available from Content' section in the slot drawer.
     Filters to instances listed in patt.raid_seasons.current_instance_ids for the
     active season. Falls back to showing all instances if current_instance_ids is empty.
+    Excluded items (Phase 1E.5) are omitted from results.
 
     Eligibility rules:
       - Armor slots: filter by character's class armor type (cloth/leather/mail/plate)
@@ -1238,6 +1289,24 @@ async def get_available_items(
             current_instance_ids = list(season_row["current_instance_ids"] or [])
             current_instance_ids += list(season_row["current_raid_ids"] or [])
 
+        # Phase 1E.5: fetch per-slot exclusions so we can hide excluded items
+        excluded_ids: list[int] = []
+        plan_row = await conn.fetchrow(
+            "SELECT id FROM guild_identity.gear_plans WHERE player_id=$1 AND character_id=$2",
+            player_id, character_id,
+        )
+        if plan_row:
+            slot_row = await conn.fetchrow(
+                """
+                SELECT excluded_item_ids
+                  FROM guild_identity.gear_plan_slots
+                 WHERE plan_id = $1 AND slot = $2
+                """,
+                plan_row["id"], slot,
+            )
+            if slot_row:
+                excluded_ids = list(slot_row["excluded_item_ids"] or [])
+
         # Normalize paired slots to canonical wow_items.slot_type
         slot_type = _SLOT_TYPE_QUERY_MAP.get(slot, slot)
 
@@ -1261,6 +1330,12 @@ async def get_available_items(
             params.append(current_instance_ids)  # $N — INTEGER[]
             season_clause = f"AND is2.blizzard_instance_id = ANY(${len(params)})"
 
+        # Exclusion filter: hide items the player has permanently excluded (Phase 1E.5)
+        exclude_clause = ""
+        if excluded_ids:
+            params.append(excluded_ids)
+            exclude_clause = f"AND wi.id != ALL(${len(params)}::int[])"
+
         # Only fetch tooltip HTML when needed for weapon stat filtering
         need_tooltip = slot in _WEAPON_SLOTS
         tooltip_col  = "wi.wowhead_tooltip_html," if need_tooltip else ""
@@ -1276,6 +1351,7 @@ async def get_available_items(
              WHERE wi.slot_type = $1
                {armor_clause}
                {season_clause}
+               {exclude_clause}
              ORDER BY wi.name, is2.instance_name, is2.encounter_name
             """,
             *params,
@@ -1318,3 +1394,102 @@ async def get_available_items(
         item.pop("wowhead_tooltip_html", None)
 
     return items
+
+
+# ── Item exclusion (Phase 1E.5) ───────────────────────────────────────────────
+
+async def add_exclusion(
+    pool: asyncpg.Pool,
+    player_id: int,
+    character_id: int,
+    slot: str,
+    blizzard_item_id: int,
+) -> bool:
+    """Append an item to the excluded_item_ids list for a gear plan slot.
+
+    Resolves blizzard_item_id → wow_items.id (internal FK).
+    Creates the slot row if it doesn't exist (desired_item_id=NULL).
+    No-ops if the item is already excluded.
+    Returns True on success, False if plan not found.
+    """
+    if slot not in WOW_SLOTS:
+        return False
+
+    async with pool.acquire() as conn:
+        plan_row = await conn.fetchrow(
+            "SELECT id FROM guild_identity.gear_plans WHERE player_id=$1 AND character_id=$2",
+            player_id, character_id,
+        )
+        if not plan_row:
+            return False
+        plan_id = plan_row["id"]
+
+        # Resolve to internal wow_items.id
+        item_row = await conn.fetchrow(
+            "SELECT id FROM guild_identity.wow_items WHERE blizzard_item_id = $1",
+            blizzard_item_id,
+        )
+        if not item_row:
+            return False
+        item_id = item_row["id"]
+
+        # Upsert slot row and append item_id if not already present
+        await conn.execute(
+            """
+            INSERT INTO guild_identity.gear_plan_slots
+                (plan_id, slot, desired_item_id, blizzard_item_id, item_name, is_locked,
+                 excluded_item_ids)
+            VALUES ($1, $2, NULL, NULL, NULL, FALSE, ARRAY[$3::int])
+            ON CONFLICT (plan_id, slot) DO UPDATE
+                SET excluded_item_ids =
+                    CASE WHEN $3 = ANY(gear_plan_slots.excluded_item_ids)
+                         THEN gear_plan_slots.excluded_item_ids
+                         ELSE array_append(gear_plan_slots.excluded_item_ids, $3)
+                    END
+            """,
+            plan_id, slot, item_id,
+        )
+        return True
+
+
+async def remove_exclusion(
+    pool: asyncpg.Pool,
+    player_id: int,
+    character_id: int,
+    slot: str,
+    blizzard_item_id: int,
+) -> bool:
+    """Remove an item from the excluded_item_ids list for a gear plan slot.
+
+    No-ops gracefully if the slot row or item doesn't exist.
+    Returns True on success, False if plan not found.
+    """
+    if slot not in WOW_SLOTS:
+        return False
+
+    async with pool.acquire() as conn:
+        plan_row = await conn.fetchrow(
+            "SELECT id FROM guild_identity.gear_plans WHERE player_id=$1 AND character_id=$2",
+            player_id, character_id,
+        )
+        if not plan_row:
+            return False
+        plan_id = plan_row["id"]
+
+        item_row = await conn.fetchrow(
+            "SELECT id FROM guild_identity.wow_items WHERE blizzard_item_id = $1",
+            blizzard_item_id,
+        )
+        if not item_row:
+            return True  # Nothing to remove
+        item_id = item_row["id"]
+
+        await conn.execute(
+            """
+            UPDATE guild_identity.gear_plan_slots
+               SET excluded_item_ids = array_remove(excluded_item_ids, $3)
+             WHERE plan_id = $1 AND slot = $2
+            """,
+            plan_id, slot, item_id,
+        )
+        return True

--- a/src/guild_portal/static/css/my_characters.css
+++ b/src/guild_portal/static/css/my_characters.css
@@ -957,7 +957,57 @@ details[open].mcn-avail-section > .mcn-avail-section__toggle::before {
 .mcn-bis-grid__check--yes { color: #4ade80; font-weight: 700; }
 .mcn-bis-grid__check--no  { color: var(--color-text-muted); opacity: 0.4; }
 
-.mcn-bis-grid__action { text-align: center; }
+.mcn-bis-grid__action { text-align: center; white-space: nowrap; }
+
+/* Phase 1E.5 — exclude (✕) button in BIS/available item rows */
+.mcn-exclude-btn {
+  background: none;
+  border: none;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-size: 0.95rem;
+  padding: 0.05rem 0.3rem;
+  border-radius: 3px;
+  line-height: 1;
+  opacity: 0.5;
+  vertical-align: middle;
+  margin-left: 0.2rem;
+}
+.mcn-exclude-btn:hover { opacity: 1; color: #f87171; background: rgba(248,113,113,0.1); }
+
+/* Phase 1E.5 — undo toast notification */
+.mcn-exclude-toast {
+  position: fixed;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--color-surface-2, #1e1e20);
+  border: 1px solid var(--color-border, #333);
+  border-radius: 0.5rem;
+  padding: 0.5rem 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  z-index: 9999;
+  font-size: 0.85rem;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.5);
+  animation: mcn-toast-in 0.2s ease;
+}
+.mcn-exclude-toast button {
+  background: var(--color-accent, #d4a84b);
+  color: #0a0a0b;
+  border: none;
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.6rem;
+  cursor: pointer;
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+.mcn-exclude-toast button:hover { opacity: 0.85; }
+@keyframes mcn-toast-in {
+  from { opacity: 0; transform: translateX(-50%) translateY(0.5rem); }
+  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
+}
 
 /* Lock button in drawer */
 .mcn-lock-btn {

--- a/src/guild_portal/static/js/my_characters.js
+++ b/src/guild_portal/static/js/my_characters.js
@@ -2090,12 +2090,22 @@ function _gpRenderDrawerBody(slotKey, sd, tc) {
     <div id="mcn-avail-body-${_gpEsc(dbSlot)}">${availBodyHtml}</div>
   </details>`;
 
+  // Phase 1E.5: excluded items section
+  const excludedItems = sd.excluded_items || [];
+  const excludedHtml = excludedItems.length > 0
+    ? `<details class="mcn-avail-section">
+        <summary class="mcn-avail-section__toggle">Excluded items (${excludedItems.length})</summary>
+        <div>${_gpRenderExcludedItems(dbSlot, excludedItems)}</div>
+       </details>`
+    : '';
+
   return `
     <div><div class="mcn-drawer-section__title">Equipped</div>${equippedHtml}</div>
     <div><div class="mcn-drawer-section__title">Your Goal</div>${goalHtml}${manualHtml}</div>
     <div><div class="mcn-drawer-section__title">Drop Location</div>${dropHtml}</div>
     <div class="mcn-drawer__bis-section"><div class="mcn-drawer-section__title">BIS Recommendations</div>${bisHtml}</div>
-    <div class="mcn-drawer__bis-section">${availHtml}</div>`;
+    <div class="mcn-drawer__bis-section">${availHtml}</div>
+    ${excludedItems.length > 0 ? `<div class="mcn-drawer__bis-section">${excludedHtml}</div>` : ''}`;
 }
 
 function _gpRenderBisGrid(slotKey, bis, tc, primaryBid, dbSlot) {
@@ -2176,10 +2186,14 @@ function _gpRenderBisGrid(slotKey, bis, tc, primaryBid, dbSlot) {
     const icon = item.icon
       ? `<img class="mcn-bis-grid__icon" src="${_gpEsc(item.icon)}" alt="" loading="lazy">`
       : `<span class="mcn-bis-grid__icon-ph"></span>`;
+    const nameEsc = _gpEsc(item.name).replace(/'/g, "&#39;");
     return `<tr>
       <td class="mcn-bis-grid__name"><div class="mcn-bis-grid__name-inner">${icon}<a href="https://www.wowhead.com/item=${item.bid}" target="_blank" rel="noopener noreferrer" style="color:inherit;text-decoration:none">${_gpEsc(item.name)}</a></div></td>
       ${cells}
-      <td class="mcn-bis-grid__action"><button class="btn btn-sm btn-secondary" type="button" style="padding:0.1rem 0.4rem;font-size:0.7rem" onclick="mcnGpSetDesiredItem('${_gpEsc(dbSlot)}',${item.bid})">Use</button></td>
+      <td class="mcn-bis-grid__action">
+        <button class="btn btn-sm btn-secondary" type="button" style="padding:0.1rem 0.4rem;font-size:0.7rem" onclick="mcnGpSetDesiredItem('${_gpEsc(dbSlot)}',${item.bid})">Use</button>
+        <button class="mcn-exclude-btn" type="button" title="Exclude this item" onclick="mcnGpExcludeItem('${_gpEsc(dbSlot)}',${item.bid},'${nameEsc}')">&times;</button>
+      </td>
     </tr>`;
   }).join('');
 
@@ -2206,6 +2220,7 @@ function _gpRenderAvailItems(dbSlot, items, tc, status) {
     const instances = [...new Set((item.sources || []).map(s => s.source_instance).filter(Boolean))];
     const instText  = instances.slice(0, 2).join(', ');
 
+    const nameEsc = _gpEsc(item.name).replace(/'/g, "&#39;");
     return `<tr>
       <td class="mcn-bis-grid__name">
         <div class="mcn-bis-grid__name-inner">
@@ -2215,7 +2230,10 @@ function _gpRenderAvailItems(dbSlot, items, tc, status) {
         ${instText ? `<div class="mcn-avail-item__inst">${_gpEsc(instText)}</div>` : ''}
       </td>
       <td class="mcn-avail-item__tracks">${trackPills}</td>
-      <td class="mcn-bis-grid__action"><button class="btn btn-sm btn-secondary" type="button" style="padding:0.1rem 0.4rem;font-size:0.7rem" onclick="mcnGpSetDesiredItem('${_gpEsc(dbSlot)}',${item.blizzard_item_id})">Use</button></td>
+      <td class="mcn-bis-grid__action">
+        <button class="btn btn-sm btn-secondary" type="button" style="padding:0.1rem 0.4rem;font-size:0.7rem" onclick="mcnGpSetDesiredItem('${_gpEsc(dbSlot)}',${item.blizzard_item_id})">Use</button>
+        <button class="mcn-exclude-btn" type="button" title="Exclude this item" onclick="mcnGpExcludeItem('${_gpEsc(dbSlot)}',${item.blizzard_item_id},'${nameEsc}')">&times;</button>
+      </td>
     </tr>`;
   }).join('');
 
@@ -2225,6 +2243,30 @@ function _gpRenderAvailItems(dbSlot, items, tc, status) {
       <th style="font-size:0.63rem;text-align:center">Tracks</th>
       <th></th>
     </tr></thead>
+    <tbody>${rows}</tbody>
+  </table>`;
+}
+
+function _gpRenderExcludedItems(dbSlot, items) {
+  if (!items || !items.length) return '';
+  const rows = items.map(item => {
+    const icon = item.icon_url
+      ? `<img class="mcn-bis-grid__icon" src="${_gpEsc(item.icon_url)}" alt="" loading="lazy" style="opacity:0.5">`
+      : `<span class="mcn-bis-grid__icon-ph"></span>`;
+    return `<tr>
+      <td class="mcn-bis-grid__name">
+        <div class="mcn-bis-grid__name-inner">
+          ${icon}
+          <a href="https://www.wowhead.com/item=${item.blizzard_item_id}" target="_blank" rel="noopener noreferrer" style="color:inherit;text-decoration:none;opacity:0.5">${_gpEsc(item.name)}</a>
+        </div>
+      </td>
+      <td class="mcn-bis-grid__action">
+        <button class="btn btn-sm btn-secondary" type="button" title="Un-exclude" style="padding:0.1rem 0.4rem;font-size:0.7rem" onclick="mcnGpUnexcludeItem('${_gpEsc(dbSlot)}',${item.blizzard_item_id})">&#8617;</button>
+      </td>
+    </tr>`;
+  }).join('');
+  return `<table class="mcn-bis-grid" style="opacity:0.8">
+    <thead><tr><th class="mcn-bis-grid__name-col">Item</th><th></th></tr></thead>
     <tbody>${rows}</tbody>
   </table>`;
 }
@@ -2369,3 +2411,67 @@ window.mcnGpPickSearchResult = async function(slot, blizzardItemId, name) {
   if (input) input.value = '';
   await window.mcnGpSetDesiredItem(slot, blizzardItemId);
 };
+
+// ── Item exclusion (Phase 1E.5) ───────────────────────────────────────────────
+
+window.mcnGpExcludeItem = async function(slot, blizzardItemId, itemName) {
+  const charId = _selectedChar?.id;
+  if (!charId) return;
+
+  const resp = await _gpFetch(`/api/v1/me/gear-plan/${charId}/slots/${slot}/exclude`, {
+    method: 'PATCH',
+    body: JSON.stringify({ blizzard_item_id: blizzardItemId }),
+  });
+
+  if (!resp.ok) {
+    _gpShowStatus(resp.error || 'Failed to exclude item', 'err');
+    return;
+  }
+
+  // Invalidate available-items cache so the excluded item disappears
+  const cacheKey = `${charId}:${slot}`;
+  delete _gpAvailCache[cacheKey];
+
+  // Reload plan (gets updated excluded_items list), then re-open drawer
+  await _gpReload();
+
+  // Show undo toast
+  _gpShowExcludeToast(slot, blizzardItemId, itemName);
+};
+
+window.mcnGpUnexcludeItem = async function(slot, blizzardItemId) {
+  const charId = _selectedChar?.id;
+  if (!charId) return;
+
+  // Dismiss toast if still showing
+  const toast = document.getElementById('mcn-exclude-toast');
+  if (toast) { clearTimeout(toast._gpTimer); toast.remove(); }
+
+  const resp = await _gpFetch(`/api/v1/me/gear-plan/${charId}/slots/${slot}/exclude`, {
+    method: 'DELETE',
+    body: JSON.stringify({ blizzard_item_id: blizzardItemId }),
+  });
+
+  if (resp.ok) {
+    // Invalidate available-items cache for this slot
+    delete _gpAvailCache[`${charId}:${slot}`];
+    await _gpReload();
+  } else {
+    _gpShowStatus(resp.error || 'Failed to un-exclude item', 'err');
+  }
+};
+
+function _gpShowExcludeToast(slot, blizzardItemId, itemName) {
+  // Remove any existing toast
+  const existing = document.getElementById('mcn-exclude-toast');
+  if (existing) { clearTimeout(existing._gpTimer); existing.remove(); }
+
+  const toast = document.createElement('div');
+  toast.id = 'mcn-exclude-toast';
+  toast.className = 'mcn-exclude-toast';
+  toast.innerHTML = `<span>Excluded <strong>${_gpEsc(itemName)}</strong></span>
+    <button type="button" onclick="mcnGpUnexcludeItem('${_gpEsc(slot)}',${blizzardItemId})">Undo</button>`;
+  document.body.appendChild(toast);
+
+  toast._gpTimer = setTimeout(() => toast.remove(), 3000);
+}

--- a/src/guild_portal/templates/member/my_characters.html
+++ b/src/guild_portal/templates/member/my_characters.html
@@ -2,7 +2,7 @@
 {% block title %}My Characters — {{ site().guild_name }}{% endblock %}
 
 {% block head %}
-<link rel="stylesheet" href="/static/css/my_characters.css?v=1.3.0">
+<link rel="stylesheet" href="/static/css/my_characters.css?v=1.4.0">
 {% endblock %}
 
 {% block content %}
@@ -156,5 +156,5 @@
 {% block scripts %}
 <script>var whTooltips = {colorLinks: true, iconizeLinks: false, renameLinks: false, hide: {sellprice: true, ilvl: false, reqlevel: false, power: false}};</script>
 <script src="https://wow.zamimg.com/widgets/power.js"></script>
-<script src="/static/js/my_characters.js?v=1.6.0"></script>
+<script src="/static/js/my_characters.js?v=1.7.0"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Migration 0093: `excluded_item_ids INTEGER[]` on `gear_plan_slots`
- Fill BIS skips excluded items and falls through to next priority candidate
- BIS recommendations and Available from Content hide excluded items per slot
- ✕ button on every BIS/available item row; 3s undo toast; collapsed Excluded items section with ↩ restore
- `PATCH`/`DELETE` `/api/v1/me/gear-plan/{character_id}/slots/{slot}/exclude` endpoints

## Test plan
- [ ] ✕ button excludes item from BIS grid and Available from Content
- [ ] Toast appears with Undo; Undo re-includes item
- [ ] Fill BIS picks next priority when top item is excluded
- [ ] Excluded items section shows at bottom of drawer (collapsed)
- [ ] ↩ button un-excludes and item reappears
- [ ] Exclusions persist across drawer open/close and page refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)