### PR TITLE
feat: Phase 1E.6 — SimC as gear source + UI polish

### DIFF
--- a/alembic/versions/0094_gear_plans_simc_source.py
+++ b/alembic/versions/0094_gear_plans_simc_source.py
@@ -1,0 +1,34 @@
+"""Add simc_imported_at and equipped_source to guild_identity.gear_plans for Phase 1E.6.
+
+Lets users switch the paperdoll equipped-gear display between Blizzard API data
+(always fresh from the background sync) and a previously imported SimC profile
+(instant snapshot from the in-game addon).
+
+Revision ID: 0094
+Revises: 0093
+"""
+
+from alembic import op
+
+revision = "0094"
+down_revision = "0093"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""
+        ALTER TABLE guild_identity.gear_plans
+        ADD COLUMN IF NOT EXISTS simc_imported_at TIMESTAMPTZ,
+        ADD COLUMN IF NOT EXISTS equipped_source VARCHAR(10)
+            NOT NULL DEFAULT 'blizzard'
+            CHECK (equipped_source IN ('blizzard', 'simc'))
+    """)
+
+
+def downgrade():
+    op.execute("""
+        ALTER TABLE guild_identity.gear_plans
+        DROP COLUMN IF EXISTS simc_imported_at,
+        DROP COLUMN IF EXISTS equipped_source
+    """)

--- a/reference/gear-plan-1-feature.md
+++ b/reference/gear-plan-1-feature.md
@@ -33,12 +33,12 @@ The guild needs to answer "what should we run this week?" from a loot perspectiv
 | **1E.3** Roster aggregation — auto-setup new members | ✅ DONE | `gear_plan_auto_setup.py` in sv_common/guild_sync; called from `_sync_one_character` after equipment commit; no-op if plan exists or no player link |
 | **1E.4** Class-eligible items in slot table | ✅ DONE | `get_available_items()` in gear_plan_service + `GET /api/v1/me/gear-plan/{character_id}/available-items?slot=`. CLASS_ARMOR_TYPE + SPEC_PRIMARY_STAT static maps; armor slots filter by class armor_type; weapon slots filter by primary stat via tooltip substring check; accessories unrestricted. Frontend: collapsible `<details>` section in slot drawer with lazy fetch + in-place update; _gpAvailCache per-char/slot; cache cleared on _gpReload(). |
 | **1E.5** Item exclusion | ✅ DONE | `excluded_item_ids INTEGER[]` on `gear_plan_slots` (migration 0093); Fill BIS skips excluded items (tries next priority candidate); BIS recommendations filter per-slot; Available from Content hides excluded items; ✕ button on every BIS/available row; 3-second undo toast; collapsed "Excluded items" ↩ section at bottom of drawer. PATCH/DELETE `/api/v1/me/gear-plan/{character_id}/slots/{slot}/exclude`. |
-| **1E.6** SimC as gear source + freshness indicator | ⬜ TODO | Parse stored `simc_profile` for item IDs + bonus IDs; `simc_imported_at` timestamp (migration); source toggle (Blizzard API / SimC Import) on paperdoll with timestamps; staleness warning if SimC >7 days; guild roster metrics always use Blizzard API |
+| **1E.6** SimC as gear source + freshness indicator | ✅ DONE | Migration 0094: `simc_imported_at TIMESTAMPTZ` + `equipped_source VARCHAR(10) CHECK('blizzard'/'simc')` on `gear_plans`. `import_simc()` sets both on import. `get_plan_detail()` overlays SimC-parsed equipped gear when `equipped_source='simc'`. `set_equipped_source()` + `PATCH /source` endpoint. Frontend (JS v1.8.0, CSS v1.5.0): source toggle bar (Blizzard API / SimC Import pill buttons), timestamps, >7-day staleness warning (yellow). SimC import modal uncommented; Import/Export SimC buttons visible. |
 | **1E.7** Help system — guided tour + FAQ | ⬜ TODO | Shepherd.js overlay tour triggered by ? button (auto-fires on first visit via localStorage); collapsible FAQ accordion at bottom of gear plan tab including SimC addon tutorial and "Where did this plan come from?" |
 
-**Active branch:** `main`
-**Last migration:** 0093
-**Last prod tag:** `prod-v0.14.0`
+**Active branch:** `feature/gear-plan-phase-1e6`
+**Last migration:** 0094
+**Last prod tag:** `prod-v0.14.1`
 
 ---
 

--- a/src/guild_portal/api/gear_plan_routes.py
+++ b/src/guild_portal/api/gear_plan_routes.py
@@ -447,7 +447,53 @@ async def set_equipped_source(
 
 
 # ---------------------------------------------------------------------------
+# POST /api/v1/me/gear-plan/{character_id}/import-equipped-simc
+# Phase 1E.6 — store SimC profile as the equipped gear source
+# ---------------------------------------------------------------------------
+
+
+@router.post("/{character_id}/import-equipped-simc")
+async def import_equipped_simc(
+    character_id: int,
+    request: Request,
+    current_player: Player = Depends(get_current_player),
+    db: AsyncSession = Depends(get_db),
+):
+    """Store SimC text as the equipped gear source for the paperdoll.
+
+    Saves simc_profile, stamps simc_imported_at, sets equipped_source='simc'.
+    Does NOT touch gear_plan_slots.
+    Body:
+        simc_text (string)
+    """
+    if not await _verify_ownership(current_player, character_id, db):
+        return JSONResponse({"ok": False, "error": "Character not linked to your account"}, status_code=403)
+
+    pool = await _get_pool(request)
+    if not pool:
+        return JSONResponse({"ok": False, "error": "Database pool unavailable"}, status_code=503)
+
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"ok": False, "error": "Invalid JSON"}, status_code=400)
+
+    simc_text: str = body.get("simc_text", "").strip()
+    if not simc_text:
+        return JSONResponse({"ok": False, "error": "simc_text is required"}, status_code=400)
+
+    await svc.get_or_create_plan(pool, current_player.id, character_id)
+
+    ok, err = await svc.store_equipped_simc(pool, current_player.id, character_id, simc_text)
+    if not ok:
+        return JSONResponse({"ok": False, "error": "Plan not found"}, status_code=404)
+
+    return JSONResponse({"ok": True})
+
+
+# ---------------------------------------------------------------------------
 # POST /api/v1/me/gear-plan/{character_id}/import-simc
+# Phase 1E.6 — import SimC as BIS goals (slot population only)
 # ---------------------------------------------------------------------------
 
 
@@ -458,8 +504,10 @@ async def import_simc(
     current_player: Player = Depends(get_current_player),
     db: AsyncSession = Depends(get_db),
 ):
-    """Paste SimC text to populate gear_plan_slots.
+    """Paste SimC text to set gear_plan_slots as BIS goals.
 
+    Overwrites all non-locked slots from the SimC string.
+    Does NOT change equipped_source or simc_profile.
     Body:
         simc_text (string)
     """
@@ -482,7 +530,7 @@ async def import_simc(
     # Ensure plan exists first
     await svc.get_or_create_plan(pool, current_player.id, character_id)
 
-    result = await svc.import_simc(pool, current_player.id, character_id, simc_text)
+    result = await svc.import_simc_goals(pool, current_player.id, character_id, simc_text)
     return JSONResponse({"ok": True, "data": result})
 
 
@@ -513,6 +561,41 @@ async def export_simc(
     return PlainTextResponse(
         simc_text,
         headers={"Content-Disposition": "attachment; filename=gear_plan.simc"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/me/gear-plan/{character_id}/export-equipped-simc
+# Phase 1E.6 — export the currently displayed equipped gear as SimC
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{character_id}/export-equipped-simc")
+async def export_equipped_simc(
+    character_id: int,
+    request: Request,
+    current_player: Player = Depends(get_current_player),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return SimC profile text for the current equipped gear source.
+
+    If equipped_source='simc', returns the stored profile.
+    If equipped_source='blizzard', generates one from character_equipment.
+    """
+    if not await _verify_ownership(current_player, character_id, db):
+        return JSONResponse({"ok": False, "error": "Character not linked to your account"}, status_code=403)
+
+    pool = await _get_pool(request)
+    if not pool:
+        return JSONResponse({"ok": False, "error": "Database pool unavailable"}, status_code=503)
+
+    simc_text = await svc.export_equipped_simc(pool, current_player.id, character_id)
+    if not simc_text:
+        return JSONResponse({"ok": False, "error": "No equipped gear data found"}, status_code=404)
+
+    return PlainTextResponse(
+        simc_text,
+        headers={"Content-Disposition": "attachment; filename=equipped_gear.simc"},
     )
 
 

--- a/src/guild_portal/api/gear_plan_routes.py
+++ b/src/guild_portal/api/gear_plan_routes.py
@@ -401,6 +401,52 @@ async def remove_item_exclusion(
 
 
 # ---------------------------------------------------------------------------
+# PATCH /api/v1/me/gear-plan/{character_id}/source
+# Phase 1E.6 — switch equipped gear source between 'blizzard' and 'simc'
+# ---------------------------------------------------------------------------
+
+
+@router.patch("/{character_id}/source")
+async def set_equipped_source(
+    character_id: int,
+    request: Request,
+    current_player: Player = Depends(get_current_player),
+    db: AsyncSession = Depends(get_db),
+):
+    """Switch the equipped gear source for the paperdoll display.
+
+    Body:
+        source (str) — 'blizzard' or 'simc'
+    """
+    if not await _verify_ownership(current_player, character_id, db):
+        return JSONResponse({"ok": False, "error": "Character not linked to your account"}, status_code=403)
+
+    pool = await _get_pool(request)
+    if not pool:
+        return JSONResponse({"ok": False, "error": "Database pool unavailable"}, status_code=503)
+
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"ok": False, "error": "Invalid JSON"}, status_code=400)
+
+    source: str = body.get("source", "")
+    if source not in ("blizzard", "simc"):
+        return JSONResponse({"ok": False, "error": "source must be 'blizzard' or 'simc'"}, status_code=400)
+
+    ok, err = await svc.set_equipped_source(pool, current_player.id, character_id, source)
+    if not ok:
+        if err == "no_simc":
+            return JSONResponse(
+                {"ok": False, "error": "No SimC profile imported yet — paste one first"},
+                status_code=409,
+            )
+        return JSONResponse({"ok": False, "error": "Plan not found"}, status_code=404)
+
+    return JSONResponse({"ok": True})
+
+
+# ---------------------------------------------------------------------------
 # POST /api/v1/me/gear-plan/{character_id}/import-simc
 # ---------------------------------------------------------------------------
 

--- a/src/guild_portal/api/gear_plan_routes.py
+++ b/src/guild_portal/api/gear_plan_routes.py
@@ -535,6 +535,34 @@ async def import_simc(
 
 
 # ---------------------------------------------------------------------------
+# POST /api/v1/me/gear-plan/{character_id}/set-goals-from-equipped
+# ---------------------------------------------------------------------------
+
+
+@router.post("/{character_id}/set-goals-from-equipped")
+async def set_goals_from_equipped(
+    character_id: int,
+    request: Request,
+    current_player: Player = Depends(get_current_player),
+    db: AsyncSession = Depends(get_db),
+):
+    """Populate gear_plan_slots from the character's Blizzard-synced equipment.
+
+    Overwrites all non-locked slots with the items currently in
+    guild_identity.character_equipment for this character.
+    """
+    if not await _verify_ownership(current_player, character_id, db):
+        return JSONResponse({"ok": False, "error": "Character not linked to your account"}, status_code=403)
+
+    pool = await _get_pool(request)
+    if not pool:
+        return JSONResponse({"ok": False, "error": "Database pool unavailable"}, status_code=503)
+
+    result = await svc.set_goals_from_equipped(pool, current_player.id, character_id)
+    return JSONResponse({"ok": True, "data": result})
+
+
+# ---------------------------------------------------------------------------
 # GET /api/v1/me/gear-plan/{character_id}/export-simc
 # ---------------------------------------------------------------------------
 

--- a/src/guild_portal/services/gear_plan_service.py
+++ b/src/guild_portal/services/gear_plan_service.py
@@ -957,21 +957,46 @@ async def get_plan_detail(
                         "is_crafted": is_crafted,
                     }
 
-                # Cross-reference quality_track from Blizzard API data.
-                # For items where track_from_bonus_ids() returned None (bonus_id
-                # map doesn't yet cover Midnight Season IDs), check if the same
-                # blizzard_item_id is in the character's Blizzard-synced equipment
-                # and borrow its quality_track from there.
-                blizzard_track_by_bid: dict[int, str] = {
-                    r["blizzard_item_id"]: r["quality_track"]
-                    for r in equip_rows
-                    if r["blizzard_item_id"] and r["quality_track"]
-                }
+                # Cross-reference quality_track from Blizzard API data using
+                # two complementary strategies:
+                #
+                # Strategy A — exact item match: if the same blizzard_item_id
+                #   exists in character_equipment with quality_track set (from
+                #   Blizzard display_string detection), borrow it directly.
+                #
+                # Strategy B — bonus_id pattern learning: build a map of
+                #   bonus_id → quality_track from all character_equipment rows
+                #   that DO have quality_track.  Midnight Season uses new bonus
+                #   IDs not yet in _DEFAULT_SIMC_BONUS_IDS; this discovers them
+                #   empirically from the items we already know the quality of.
+                #   For each SimC item, scan its bonus_ids against this map.
+                #   First match wins (quality tier IDs are globally unique in WoW).
+                blizzard_track_by_bid: dict[int, str] = {}
+                bonus_id_to_track: dict[int, str] = {}
+                for r in equip_rows:
+                    qt = r["quality_track"]
+                    if not qt:
+                        continue
+                    bid = r["blizzard_item_id"]
+                    if bid:
+                        blizzard_track_by_bid[bid] = qt
+                    for bonus_id in (r.get("bonus_ids") or []):
+                        if bonus_id not in bonus_id_to_track:
+                            bonus_id_to_track[bonus_id] = qt
+
                 for item_data in simc_equipped.values():
-                    if item_data.get("quality_track") is None:
-                        bid = item_data.get("blizzard_item_id")
-                        if bid and bid in blizzard_track_by_bid:
-                            item_data["quality_track"] = blizzard_track_by_bid[bid]
+                    if item_data.get("quality_track") is not None:
+                        continue
+                    bid = item_data.get("blizzard_item_id")
+                    # Strategy A: exact item match
+                    if bid and bid in blizzard_track_by_bid:
+                        item_data["quality_track"] = blizzard_track_by_bid[bid]
+                        continue
+                    # Strategy B: scan SimC bonus_ids for known quality markers
+                    for bonus_id in (item_data.get("bonus_ids") or []):
+                        if bonus_id in bonus_id_to_track:
+                            item_data["quality_track"] = bonus_id_to_track[bonus_id]
+                            break
 
                 equipped_by_slot = simc_equipped
 

--- a/src/guild_portal/services/gear_plan_service.py
+++ b/src/guild_portal/services/gear_plan_service.py
@@ -586,15 +586,52 @@ async def delete_plan(
         return result != "DELETE 0"
 
 
-async def import_simc(
+async def store_equipped_simc(
+    pool: asyncpg.Pool,
+    player_id: int,
+    character_id: int,
+    simc_text: str,
+) -> tuple[bool, str]:
+    """Store SimC profile as the equipped gear source.
+
+    Saves raw simc_text, stamps simc_imported_at, sets equipped_source='simc'.
+    Does NOT touch gear_plan_slots — BIS goals are managed separately via
+    import_simc_goals().
+    Returns (success, error_code).
+    """
+    async with pool.acquire() as conn:
+        plan_row = await conn.fetchrow(
+            "SELECT id FROM guild_identity.gear_plans WHERE player_id=$1 AND character_id=$2",
+            player_id, character_id,
+        )
+        if not plan_row:
+            return False, "not_found"
+
+        await conn.execute(
+            """
+            UPDATE guild_identity.gear_plans
+               SET simc_profile     = $1,
+                   simc_imported_at = NOW(),
+                   equipped_source  = 'simc',
+                   updated_at       = NOW()
+             WHERE id = $2
+            """,
+            simc_text, plan_row["id"],
+        )
+    return True, ""
+
+
+async def import_simc_goals(
     pool: asyncpg.Pool,
     player_id: int,
     character_id: int,
     simc_text: str,
 ) -> dict:
-    """Parse SimC text and populate gear_plan_slots.
+    """Parse SimC text and populate gear_plan_slots as BIS goals.
 
-    Overwrites all non-locked slots.  Stores the raw simc_text on the plan.
+    Overwrites all non-locked slots with items from the SimC string.
+    Does NOT change equipped_source or simc_profile — those are managed
+    separately by store_equipped_simc().
     Returns {"populated": N, "skipped_locked": M, "unrecognised": K}.
     """
     slots = parse_gear_slots(simc_text)
@@ -609,19 +646,6 @@ async def import_simc(
         if not plan_row:
             return {"populated": 0, "skipped_locked": 0, "unrecognised": 0}
         plan_id = plan_row["id"]
-
-        # Store raw simc text; mark as imported and switch source to simc
-        await conn.execute(
-            """
-            UPDATE guild_identity.gear_plans
-               SET simc_profile = $1,
-                   simc_imported_at = NOW(),
-                   equipped_source = 'simc',
-                   updated_at = NOW()
-             WHERE id = $2
-            """,
-            simc_text, plan_id,
-        )
 
         locked_rows = await conn.fetch(
             "SELECT slot FROM guild_identity.gear_plan_slots WHERE plan_id=$1 AND is_locked=TRUE",
@@ -771,6 +795,69 @@ async def export_simc(
     )
 
 
+async def export_equipped_simc(
+    pool: asyncpg.Pool,
+    player_id: int,
+    character_id: int,
+) -> Optional[str]:
+    """Generate SimC profile text from the current equipped gear source.
+
+    If equipped_source='simc', returns the stored simc_profile directly.
+    If equipped_source='blizzard', builds a SimC string from character_equipment.
+    Returns None if no data is available.
+    """
+    async with pool.acquire() as conn:
+        plan_row = await conn.fetchrow(
+            """
+            SELECT gp.id, gp.equipped_source, gp.simc_profile,
+                   wc.character_name, wc.realm_slug,
+                   s.name AS spec_name,
+                   c.name AS class_name
+              FROM guild_identity.gear_plans gp
+              JOIN guild_identity.wow_characters wc ON wc.id = gp.character_id
+              LEFT JOIN guild_identity.specializations s ON s.id = gp.spec_id
+              LEFT JOIN guild_identity.classes c ON c.id = wc.class_id
+             WHERE gp.player_id=$1 AND gp.character_id=$2
+            """,
+            player_id, character_id,
+        )
+        if not plan_row:
+            return None
+
+        # If SimC is the equipped source, return the stored profile verbatim
+        if plan_row["equipped_source"] == "simc" and plan_row["simc_profile"]:
+            return plan_row["simc_profile"]
+
+        # Otherwise build from character_equipment (Blizzard API data)
+        equip_rows = await conn.fetch(
+            """
+            SELECT ce.slot, ce.blizzard_item_id,
+                   COALESCE(wi.name, ce.item_name) AS item_name,
+                   ce.bonus_ids, ce.enchant_id, ce.gem_ids
+              FROM guild_identity.character_equipment ce
+              LEFT JOIN guild_identity.wow_items wi ON wi.blizzard_item_id = ce.blizzard_item_id
+             WHERE ce.character_id = $1
+            """,
+            character_id,
+        )
+
+    if not equip_rows:
+        return None
+
+    char_name = plan_row["character_name"] or "Unknown"
+    spec_name = (plan_row["spec_name"] or "").lower()
+    class_name = (plan_row["class_name"] or "").lower().replace(" ", "_")
+    realm = plan_row["realm_slug"] or "unknown"
+
+    return export_gear_plan(
+        plan_slots=[dict(r) for r in equip_rows],
+        char_name=char_name,
+        spec=spec_name,
+        wow_class=class_name,
+        realm=realm,
+    )
+
+
 async def get_plan_detail(
     pool: asyncpg.Pool,
     player_id: int,
@@ -869,6 +956,23 @@ async def get_plan_detail(
                         "icon_url": item_info.get("icon_url"),
                         "is_crafted": is_crafted,
                     }
+
+                # Cross-reference quality_track from Blizzard API data.
+                # For items where track_from_bonus_ids() returned None (bonus_id
+                # map doesn't yet cover Midnight Season IDs), check if the same
+                # blizzard_item_id is in the character's Blizzard-synced equipment
+                # and borrow its quality_track from there.
+                blizzard_track_by_bid: dict[int, str] = {
+                    r["blizzard_item_id"]: r["quality_track"]
+                    for r in equip_rows
+                    if r["blizzard_item_id"] and r["quality_track"]
+                }
+                for item_data in simc_equipped.values():
+                    if item_data.get("quality_track") is None:
+                        bid = item_data.get("blizzard_item_id")
+                        if bid and bid in blizzard_track_by_bid:
+                            item_data["quality_track"] = blizzard_track_by_bid[bid]
+
                 equipped_by_slot = simc_equipped
 
         # Build bid → equipment data lookup BEFORE _normalize_paired_slot swaps

--- a/src/guild_portal/services/gear_plan_service.py
+++ b/src/guild_portal/services/gear_plan_service.py
@@ -694,6 +694,80 @@ async def import_simc_goals(
     return {"populated": populated, "skipped_locked": skipped_locked, "unrecognised": unrecognised}
 
 
+async def set_goals_from_equipped(
+    pool: asyncpg.Pool,
+    player_id: int,
+    character_id: int,
+) -> dict:
+    """Copy character_equipment rows into gear_plan_slots as BIS goals.
+
+    Uses the Blizzard API-synced equipment (character_equipment table) as the
+    source of truth.  Overwrites all non-locked slots.
+    Returns {"populated": N, "skipped_locked": M}.
+    """
+    async with pool.acquire() as conn:
+        plan_row = await conn.fetchrow(
+            "SELECT id FROM guild_identity.gear_plans WHERE player_id=$1 AND character_id=$2",
+            player_id, character_id,
+        )
+        if not plan_row:
+            return {"populated": 0, "skipped_locked": 0}
+        plan_id = plan_row["id"]
+
+        locked_rows = await conn.fetch(
+            "SELECT slot FROM guild_identity.gear_plan_slots WHERE plan_id=$1 AND is_locked=TRUE",
+            plan_id,
+        )
+        locked_slots = {r["slot"] for r in locked_rows}
+
+        equip_rows = await conn.fetch(
+            """
+            SELECT ce.slot, ce.blizzard_item_id, ce.item_name,
+                   wi.id AS wow_item_id
+              FROM guild_identity.character_equipment ce
+              LEFT JOIN guild_identity.wow_items wi
+                     ON wi.blizzard_item_id = ce.blizzard_item_id
+             WHERE ce.character_id = $1
+            """,
+            character_id,
+        )
+
+        populated = 0
+        skipped_locked = 0
+
+        for row in equip_rows:
+            slot = row["slot"]
+            if slot not in WOW_SLOTS:
+                continue
+            if slot in locked_slots:
+                skipped_locked += 1
+                continue
+
+            bid = row["blizzard_item_id"]
+            if not bid:
+                continue
+
+            item_name = row["item_name"] or f"Item {bid}"
+            desired_item_id = row["wow_item_id"]  # may be None if not yet in wow_items
+
+            await conn.execute(
+                """
+                INSERT INTO guild_identity.gear_plan_slots
+                    (plan_id, slot, desired_item_id, blizzard_item_id, item_name, is_locked)
+                VALUES ($1, $2, $3, $4, $5, FALSE)
+                ON CONFLICT (plan_id, slot) DO UPDATE
+                    SET desired_item_id = EXCLUDED.desired_item_id,
+                        blizzard_item_id = EXCLUDED.blizzard_item_id,
+                        item_name        = EXCLUDED.item_name
+                    WHERE gear_plan_slots.is_locked = FALSE
+                """,
+                plan_id, slot, desired_item_id, bid, item_name,
+            )
+            populated += 1
+
+    return {"populated": populated, "skipped_locked": skipped_locked}
+
+
 async def set_equipped_source(
     pool: asyncpg.Pool,
     player_id: int,

--- a/src/guild_portal/services/gear_plan_service.py
+++ b/src/guild_portal/services/gear_plan_service.py
@@ -333,7 +333,8 @@ async def get_or_create_plan(
         row = await conn.fetchrow(
             """
             SELECT id, player_id, character_id, spec_id, hero_talent_id,
-                   bis_source_id, simc_profile, is_active
+                   bis_source_id, simc_profile, is_active,
+                   simc_imported_at, equipped_source
               FROM guild_identity.gear_plans
              WHERE player_id = $1 AND character_id = $2
             """,
@@ -370,7 +371,8 @@ async def get_or_create_plan(
                 (player_id, character_id, spec_id, hero_talent_id, bis_source_id, is_active)
             VALUES ($1, $2, $3, $4, $5, TRUE)
             RETURNING id, player_id, character_id, spec_id, hero_talent_id,
-                      bis_source_id, simc_profile, is_active
+                      bis_source_id, simc_profile, is_active,
+                      simc_imported_at, equipped_source
             """,
             player_id, character_id, spec_id, hero_talent_id, bis_source_id,
         )
@@ -608,10 +610,16 @@ async def import_simc(
             return {"populated": 0, "skipped_locked": 0, "unrecognised": 0}
         plan_id = plan_row["id"]
 
-        # Store raw simc text
+        # Store raw simc text; mark as imported and switch source to simc
         await conn.execute(
-            "UPDATE guild_identity.gear_plans SET simc_profile=$1, updated_at=NOW()"
-            " WHERE id=$2",
+            """
+            UPDATE guild_identity.gear_plans
+               SET simc_profile = $1,
+                   simc_imported_at = NOW(),
+                   equipped_source = 'simc',
+                   updated_at = NOW()
+             WHERE id = $2
+            """,
             simc_text, plan_id,
         )
 
@@ -660,6 +668,46 @@ async def import_simc(
             populated += 1
 
     return {"populated": populated, "skipped_locked": skipped_locked, "unrecognised": unrecognised}
+
+
+async def set_equipped_source(
+    pool: asyncpg.Pool,
+    player_id: int,
+    character_id: int,
+    source: str,
+) -> tuple[bool, Optional[str]]:
+    """Switch the plan's equipped_source between 'blizzard' and 'simc'.
+
+    Returns (success, error_message).  Switching to 'simc' requires a stored
+    simc_profile; if none exists, returns (False, 'no_simc').
+    """
+    if source not in ("blizzard", "simc"):
+        return False, "invalid_source"
+
+    async with pool.acquire() as conn:
+        plan_row = await conn.fetchrow(
+            """
+            SELECT id, simc_profile
+              FROM guild_identity.gear_plans
+             WHERE player_id = $1 AND character_id = $2
+            """,
+            player_id, character_id,
+        )
+        if not plan_row:
+            return False, "not_found"
+
+        if source == "simc" and not plan_row["simc_profile"]:
+            return False, "no_simc"
+
+        await conn.execute(
+            """
+            UPDATE guild_identity.gear_plans
+               SET equipped_source = $1, updated_at = NOW()
+             WHERE id = $2
+            """,
+            source, plan_row["id"],
+        )
+    return True, None
 
 
 async def export_simc(
@@ -737,13 +785,19 @@ async def get_plan_detail(
             """
             SELECT gp.id, gp.player_id, gp.character_id, gp.spec_id,
                    gp.hero_talent_id, gp.bis_source_id, gp.is_active,
+                   gp.simc_profile, gp.simc_imported_at, gp.equipped_source,
                    s.name AS spec_name,
                    ht.name AS hero_talent_name,
-                   bls.name AS bis_source_name
+                   bls.name AS bis_source_name,
+                   wc.last_equipment_sync AS blizzard_synced_at,
+                   c.name AS class_name,
+                   s.name AS spec_name_for_stat
               FROM guild_identity.gear_plans gp
               LEFT JOIN guild_identity.specializations s ON s.id = gp.spec_id
               LEFT JOIN guild_identity.hero_talents ht ON ht.id = gp.hero_talent_id
               LEFT JOIN guild_identity.bis_list_sources bls ON bls.id = gp.bis_source_id
+              LEFT JOIN guild_identity.wow_characters wc ON wc.id = gp.character_id
+              LEFT JOIN guild_identity.classes c ON c.id = wc.class_id
              WHERE gp.player_id = $1 AND gp.character_id = $2
             """,
             player_id, character_id,
@@ -774,6 +828,48 @@ async def get_plan_detail(
             d = dict(r)
             d["is_crafted"] = is_crafted_item(d.get("bonus_ids") or [])
             equipped_by_slot[r["slot"]] = d
+
+        # Phase 1E.6: If equipped_source='simc' and a stored simc_profile exists,
+        # parse it and override equipped_by_slot with SimC-sourced gear data.
+        # item_level is not available in SimC profiles so it shows as null in the UI.
+        equipped_source = plan_row["equipped_source"] or "blizzard"
+        simc_profile_text = plan_row["simc_profile"]
+
+        if equipped_source == "simc" and simc_profile_text:
+            simc_slots = parse_gear_slots(simc_profile_text)
+            if simc_slots:
+                simc_bids = [s.blizzard_item_id for s in simc_slots if s.blizzard_item_id]
+                simc_item_cache: dict[int, dict] = {}
+                if simc_bids:
+                    simc_item_rows = await conn.fetch(
+                        """
+                        SELECT blizzard_item_id, name, icon_url
+                          FROM guild_identity.wow_items
+                         WHERE blizzard_item_id = ANY($1::int[])
+                        """,
+                        simc_bids,
+                    )
+                    simc_item_cache = {r["blizzard_item_id"]: dict(r) for r in simc_item_rows}
+
+                simc_equipped: dict[str, dict] = {}
+                for simc_slot in simc_slots:
+                    slot_key = simc_slot.slot
+                    bid = simc_slot.blizzard_item_id
+                    item_info = simc_item_cache.get(bid, {})
+                    is_crafted = is_crafted_item(simc_slot.bonus_ids)
+                    simc_equipped[slot_key] = {
+                        "slot": slot_key,
+                        "blizzard_item_id": bid,
+                        "item_name": item_info.get("name") or f"Item {bid}",
+                        "item_level": None,
+                        "quality_track": simc_slot.quality_track,
+                        "enchant_id": simc_slot.enchant_id,
+                        "gem_ids": simc_slot.gem_ids,
+                        "bonus_ids": simc_slot.bonus_ids,
+                        "icon_url": item_info.get("icon_url"),
+                        "is_crafted": is_crafted,
+                    }
+                equipped_by_slot = simc_equipped
 
         # Build bid → equipment data lookup BEFORE _normalize_paired_slot swaps
         # ring/trinket slot assignments.  Crafted detection must be slot-order-
@@ -1199,8 +1295,15 @@ async def get_plan_detail(
             "excluded_items": excluded_items,
         }
 
+    plan_dict = dict(plan_row)
+    # Serialize timestamps to ISO strings for JSON
+    for ts_field in ("simc_imported_at", "blizzard_synced_at"):
+        val = plan_dict.get(ts_field)
+        if val is not None:
+            plan_dict[ts_field] = val.isoformat()
+
     return {
-        "plan": dict(plan_row),
+        "plan": plan_dict,
         "slots": slots_data,
         "bis_sources": [{**dict(r), "has_hero_talent_variants": r["id"] in ht_source_ids} for r in source_list],
         "hero_talents": ht_list,

--- a/src/guild_portal/static/css/my_characters.css
+++ b/src/guild_portal/static/css/my_characters.css
@@ -1335,17 +1335,15 @@ details[open].mcn-avail-section > .mcn-avail-section__toggle::before {
 .mcn-gt__name {
   font-size: 0.77rem;
   color: var(--color-text);
-  text-decoration: none;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 160px;
+  white-space: normal;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
   display: block;
 }
-.mcn-gt__name:hover {
-  text-decoration: underline;
-  color: var(--color-accent);
-}
+
+/* Wowhead icon links — popup on hover, no layout disruption */
+.mcn-wh-link { display: inline-block; line-height: 0; flex-shrink: 0; }
+.mcn-wh-link:hover { opacity: 0.8; }
 
 .mcn-gt__meta {
   display: flex;

--- a/src/guild_portal/static/css/my_characters.css
+++ b/src/guild_portal/static/css/my_characters.css
@@ -2038,18 +2038,21 @@ details[open].mcn-avail-section > .mcn-avail-section__toggle::before {
 .mcn-gp-sections {
   display: flex;
   gap: 0.75rem;
-  flex-wrap: wrap;
   margin-bottom: 0.75rem;
 }
 
 .mcn-gp-section {
-  flex: 0 0 auto;
-  min-width: 220px;
+  min-width: 0;   /* prevent flex blowout */
   border: 1px solid var(--color-border);
   border-radius: 8px;
   overflow: hidden;
   background: var(--color-bg-card);
 }
+
+/* Equipped Gear Source — 40% */
+.mcn-gp-section:first-child { flex: 0 0 38%; }
+/* BIS Sourcing — fills remaining ~60% */
+.mcn-gp-section:last-child  { flex: 1 1 0; }
 
 .mcn-gp-section__hdr {
   display: flex;
@@ -2184,6 +2187,8 @@ details[open].mcn-avail-section > .mcn-avail-section__toggle::before {
   color: var(--color-text-muted);
   margin: 0;
   line-height: 1.5;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
 }
 
 .mcn-gp-src-stale {

--- a/src/guild_portal/static/css/my_characters.css
+++ b/src/guild_portal/static/css/my_characters.css
@@ -2043,7 +2043,7 @@ details[open].mcn-avail-section > .mcn-avail-section__toggle::before {
 }
 
 .mcn-gp-section {
-  flex: 1 1 260px;
+  flex: 0 0 auto;
   min-width: 220px;
   border: 1px solid var(--color-border);
   border-radius: 8px;
@@ -2091,6 +2091,10 @@ details[open].mcn-avail-section > .mcn-avail-section__toggle::before {
 
 .mcn-gp-stab {
   flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
   background: transparent;
   border: none;
   border-right: 1px solid var(--color-border);
@@ -2110,6 +2114,20 @@ details[open].mcn-avail-section > .mcn-avail-section__toggle::before {
   font-weight: 700;
   cursor: default;
 }
+/* Status indicator dot on tab */
+.mcn-gp-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: transparent;
+  border: 1px solid currentColor;
+  opacity: 0.5;
+}
+.mcn-gp-dot--green  { background: #4ade80; border-color: #4ade80; opacity: 1; box-shadow: 0 0 4px #4ade80; }
+.mcn-gp-dot--amber  { background: #f59e0b; border-color: #f59e0b; opacity: 1; }
+.mcn-gp-dot--red    { background: #f87171; border-color: #f87171; opacity: 1; }
+.mcn-gp-dot--off    { background: transparent; border-color: var(--color-border); opacity: 0.4; }
 
 .mcn-gp-panel {
   padding: 0.65rem 0.75rem;
@@ -2120,6 +2138,8 @@ details[open].mcn-avail-section > .mcn-avail-section__toggle::before {
   flex-direction: column;
   gap: 0.5rem;
 }
+/* Must come AFTER display rules — overrides flex/block to hide panels */
+.mcn-gp-panel[hidden] { display: none !important; }
 
 .mcn-gp-sync-row {
   display: flex;

--- a/src/guild_portal/static/css/my_characters.css
+++ b/src/guild_portal/static/css/my_characters.css
@@ -2033,74 +2033,144 @@ details[open].mcn-avail-section > .mcn-avail-section__toggle::before {
   white-space: nowrap;
 }
 
-/* ── Gear plan source toggle (Phase 1E.6) ──────────────────────────────────── */
+/* ── Gear plan two-section layout (Phase 1E.6 redesign) ────────────────────── */
 
-.mcn-gp-source-bar {
+.mcn-gp-sections {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.75rem;
+}
+
+.mcn-gp-section {
+  flex: 1 1 260px;
+  min-width: 220px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--color-bg-card);
+}
+
+.mcn-gp-section__hdr {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  margin-bottom: 0.6rem;
-  flex-wrap: wrap;
+  justify-content: space-between;
+  padding: 0.45rem 0.75rem;
+  border-bottom: 1px solid var(--color-border);
+  background: rgba(255,255,255,0.03);
 }
 
-.mcn-gp-source-pills {
-  display: flex;
-  gap: 0;
-  border-radius: 6px;
-  overflow: hidden;
-  border: 1px solid var(--color-border);
-  flex-shrink: 0;
+.mcn-gp-section__title {
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
 }
 
-.mcn-gp-source-pill {
+.mcn-gp-section__export {
   background: transparent;
   border: none;
   color: var(--color-text-muted);
-  font-size: 0.78rem;
+  cursor: pointer;
+  font-size: 0.85rem;
+  padding: 0.1rem 0.25rem;
+  border-radius: 3px;
+  transition: color 0.15s, background 0.15s;
+  line-height: 1;
+}
+.mcn-gp-section__export:hover {
+  color: var(--color-accent);
+  background: rgba(212,168,75,0.1);
+}
+
+.mcn-gp-section__tabs {
+  display: flex;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.mcn-gp-stab {
+  flex: 1;
+  background: transparent;
+  border: none;
+  border-right: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  font-size: 0.76rem;
   font-weight: 500;
-  padding: 0.3rem 0.75rem;
+  padding: 0.35rem 0.5rem;
   cursor: pointer;
   transition: background 0.15s, color 0.15s;
   white-space: nowrap;
 }
-
-.mcn-gp-source-pill:hover {
-  background: var(--color-bg-card);
-  color: var(--color-text);
-}
-
-.mcn-gp-source-pill.is-active {
+.mcn-gp-stab:last-child { border-right: none; }
+.mcn-gp-stab:hover { background: rgba(255,255,255,0.05); color: var(--color-text); }
+.mcn-gp-stab.is-active {
   background: var(--color-accent);
   color: #000;
   font-weight: 700;
   cursor: default;
 }
 
-.mcn-gp-source-pill + .mcn-gp-source-pill {
-  border-left: 1px solid var(--color-border);
+.mcn-gp-panel {
+  padding: 0.65rem 0.75rem;
 }
 
-.mcn-gp-source-meta {
-  flex: 1;
-  min-width: 0;
+.mcn-gp-panel--simc {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.mcn-gp-sync-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
 }
 
 .mcn-gp-src-ts {
   font-size: 0.72rem;
   color: var(--color-text-muted);
+  flex: 1;
+  min-width: 0;
 }
 
 .mcn-gp-src-ts--none {
   font-style: italic;
 }
 
-.mcn-gp-src-stale {
+.mcn-gp-textarea {
   width: 100%;
-  font-size: 0.75rem;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  color: var(--color-text);
+  font-size: 0.72rem;
+  font-family: monospace;
+  padding: 0.4rem 0.5rem;
+  resize: vertical;
+  box-sizing: border-box;
+}
+.mcn-gp-textarea:focus { border-color: var(--color-accent-dim); outline: none; }
+
+.mcn-gp-panel-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.mcn-gp-blurb {
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.mcn-gp-src-stale {
+  font-size: 0.73rem;
   color: #f59e0b;
   background: rgba(245, 158, 11, 0.1);
   border: 1px solid rgba(245, 158, 11, 0.3);
   border-radius: 4px;
-  padding: 0.3rem 0.6rem;
-  margin-top: -0.2rem;
+  padding: 0.25rem 0.5rem;
 }

--- a/src/guild_portal/static/css/my_characters.css
+++ b/src/guild_portal/static/css/my_characters.css
@@ -2032,3 +2032,75 @@ details[open].mcn-avail-section > .mcn-avail-section__toggle::before {
   color: var(--color-text-muted);
   white-space: nowrap;
 }
+
+/* ── Gear plan source toggle (Phase 1E.6) ──────────────────────────────────── */
+
+.mcn-gp-source-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.mcn-gp-source-pills {
+  display: flex;
+  gap: 0;
+  border-radius: 6px;
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  flex-shrink: 0;
+}
+
+.mcn-gp-source-pill {
+  background: transparent;
+  border: none;
+  color: var(--color-text-muted);
+  font-size: 0.78rem;
+  font-weight: 500;
+  padding: 0.3rem 0.75rem;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  white-space: nowrap;
+}
+
+.mcn-gp-source-pill:hover {
+  background: var(--color-bg-card);
+  color: var(--color-text);
+}
+
+.mcn-gp-source-pill.is-active {
+  background: var(--color-accent);
+  color: #000;
+  font-weight: 700;
+  cursor: default;
+}
+
+.mcn-gp-source-pill + .mcn-gp-source-pill {
+  border-left: 1px solid var(--color-border);
+}
+
+.mcn-gp-source-meta {
+  flex: 1;
+  min-width: 0;
+}
+
+.mcn-gp-src-ts {
+  font-size: 0.72rem;
+  color: var(--color-text-muted);
+}
+
+.mcn-gp-src-ts--none {
+  font-style: italic;
+}
+
+.mcn-gp-src-stale {
+  width: 100%;
+  font-size: 0.75rem;
+  color: #f59e0b;
+  background: rgba(245, 158, 11, 0.1);
+  border: 1px solid rgba(245, 158, 11, 0.3);
+  border-radius: 4px;
+  padding: 0.3rem 0.6rem;
+  margin-top: -0.2rem;
+}

--- a/src/guild_portal/static/js/my_characters.js
+++ b/src/guild_portal/static/js/my_characters.js
@@ -1654,7 +1654,21 @@ function _gpRenderCenterPanel(data) {
   const simcAgeDays = simcAt ? (Date.now() - simcAt.getTime()) / 86400000 : null;
   const simcStale   = simcAgeDays !== null && simcAgeDays > 7;
 
-  // Blizzard panel content
+  // ── Status dots for equipped tabs ──────────────────────────────────────
+  // Most recently updated tab = green; within 7d of the other = amber;
+  // >7d older than the other = red; no data = off/blank.
+  function _eqDot(thisAt, otherAt) {
+    if (!thisAt) return '<span class="mcn-gp-dot mcn-gp-dot--off"></span>';
+    if (!otherAt) return '<span class="mcn-gp-dot mcn-gp-dot--green"></span>';
+    const diffDays = (thisAt.getTime() - otherAt.getTime()) / 86400000;
+    if (diffDays >= 0) return '<span class="mcn-gp-dot mcn-gp-dot--green"></span>';
+    if (Math.abs(diffDays) <= 7) return '<span class="mcn-gp-dot mcn-gp-dot--amber"></span>';
+    return '<span class="mcn-gp-dot mcn-gp-dot--red"></span>';
+  }
+  const blizzDot = _eqDot(blizzardAt, simcAt);
+  const simcDot  = _eqDot(simcAt, blizzardAt);
+
+  // Blizzard panel — sync timestamp + Sync Now button
   const blizzardPanel = `
     <div class="mcn-gp-panel" id="mcn-gp-panel-blizzard"${isEqBlizzard ? '' : ' hidden'}>
       <div class="mcn-gp-sync-row">
@@ -1665,7 +1679,8 @@ function _gpRenderCenterPanel(data) {
       </div>
     </div>`;
 
-  // SimC equipped panel content — shows textarea if no import yet OR user clicked Re-import
+  // SimC equipped panel — shows textarea if no import yet OR user clicked Re-import
+  // Profile is persisted in DB; switching tabs does not lose it.
   const showSimcInput = isEqSimC && (_gpEquippedShowInput || !simcAt);
   const simcPanel = `
     <div class="mcn-gp-panel mcn-gp-panel--simc" id="mcn-gp-panel-simc"${isEqSimC ? '' : ' hidden'}>
@@ -1680,7 +1695,7 @@ function _gpRenderCenterPanel(data) {
           <span class="mcn-gp-src-ts">Snapshot from ${_gpTimeAgo(simcAt)}</span>
           <button id="mcn-gp-btn-reimport-eq" class="btn btn-secondary btn-sm" type="button">Re-import</button>
         </div>
-        ${simcStale ? `<div class="mcn-gp-src-stale">&#9888; SimC data is ${Math.floor(simcAgeDays)} days old \u2014 consider re-importing</div>` : ''}`}
+        ${simcStale ? `<div class="mcn-gp-src-stale">&#9888; ${Math.floor(simcAgeDays)} days old \u2014 consider re-importing</div>` : ''}`}
     </div>`;
 
   const equippedSection = `
@@ -1691,9 +1706,9 @@ function _gpRenderCenterPanel(data) {
       </div>
       <div class="mcn-gp-section__tabs">
         <button class="mcn-gp-stab${isEqBlizzard ? ' is-active' : ''}"
-                onclick="_gpOnEquippedTab('blizzard')" type="button">Blizzard API</button>
+                onclick="_gpOnEquippedTab('blizzard')" type="button">${blizzDot} Blizzard API</button>
         <button class="mcn-gp-stab${isEqSimC ? ' is-active' : ''}"
-                onclick="_gpOnEquippedTab('simc')" type="button">SimC Import</button>
+                onclick="_gpOnEquippedTab('simc')" type="button">${simcDot} SimC Import</button>
       </div>
       ${blizzardPanel}
       ${simcPanel}

--- a/src/guild_portal/static/js/my_characters.js
+++ b/src/guild_portal/static/js/my_characters.js
@@ -1708,7 +1708,7 @@ function _gpRenderCenterPanel(data) {
         <button class="mcn-gp-stab${isEqBlizzard ? ' is-active' : ''}"
                 onclick="_gpOnEquippedTab('blizzard')" type="button">${blizzDot} Blizzard API</button>
         <button class="mcn-gp-stab${isEqSimC ? ' is-active' : ''}"
-                onclick="_gpOnEquippedTab('simc')" type="button">${simcDot} SimC Import</button>
+                onclick="_gpOnEquippedTab('simc')" type="button">${simcDot} Import SimC</button>
       </div>
       ${blizzardPanel}
       ${simcPanel}
@@ -1747,7 +1747,10 @@ function _gpRenderCenterPanel(data) {
 
   const bisCurrentPanel = `
     <div class="mcn-gp-panel" id="mcn-gp-panel-bis-current"${bisTab === 'current' ? '' : ' hidden'}>
-      <p class="mcn-gp-blurb">Your BIS goals reflect your current equipped gear. Switch to <strong>Use a Guide</strong> to get upgrade recommendations, or <strong>Import SimC</strong> to paste a theorycrafter&#39;s profile.</p>
+      <p class="mcn-gp-blurb">Set your BIS goals to match your currently equipped gear. Unlocked slots will be updated to what you have on right now.</p>
+      <div class="mcn-gp-panel-actions">
+        <button id="mcn-gp-btn-set-from-eq" class="btn btn-primary btn-sm" type="button">Set Goals to Current Gear</button>
+      </div>
     </div>`;
 
   const bisGuidePanel = `
@@ -1818,6 +1821,7 @@ function _gpRenderCenterPanel(data) {
   document.getElementById('mcn-gp-btn-export-eq')  ?.addEventListener('click', _gpOnExportEquipped);
 
   // Wire BIS section
+  document.getElementById('mcn-gp-btn-set-from-eq') ?.addEventListener('click',  _gpOnSetGoalsFromEquipped);
   document.getElementById('mcn-gp-ht-sel')          ?.addEventListener('change', _gpOnConfigChange);
   document.getElementById('mcn-gp-src-sel')          ?.addEventListener('change', _gpOnConfigChange);
   document.getElementById('mcn-gp-btn-fill')         ?.addEventListener('click',  _gpOnPopulate);
@@ -2099,6 +2103,22 @@ async function _gpOnImportEquipped() {
     await _gpReload();
   } else {
     _gpShowStatus(resp.error || 'Import failed', 'err');
+  }
+}
+
+async function _gpOnSetGoalsFromEquipped() {
+  const charId = _selectedChar?.id;
+  if (!charId) return;
+  _gpShowStatus('Copying equipped gear to goals\u2026', 'info');
+  const resp = await _gpFetch(`/api/v1/me/gear-plan/${charId}/set-goals-from-equipped`, { method: 'POST' });
+  if (resp.ok) {
+    const d = resp.data || {};
+    const msg = `Goals set: ${d.populated || 0} slot${d.populated !== 1 ? 's' : ''}${d.skipped_locked ? `, ${d.skipped_locked} locked skipped` : ''}`;
+    _gpBisTab = 'guide';
+    _gpShowStatus(msg, 'ok');
+    await _gpReload();
+  } else {
+    _gpShowStatus(resp.error || 'Failed to set goals', 'err');
   }
 }
 

--- a/src/guild_portal/static/js/my_characters.js
+++ b/src/guild_portal/static/js/my_characters.js
@@ -1534,7 +1534,7 @@ function _gpRenderGearTable(slots, tc) {
         ? `<span class="mcn-track-pill" style="background:${_gpEsc(qc)}">${_gpEsc(eq.quality_track)}</span>`
         : '';
       const icon = eq.icon_url
-        ? `<a href="https://www.wowhead.com/item=${eq.blizzard_item_id}" target="_blank" rel="noopener noreferrer">
+        ? `<a href="https://www.wowhead.com/item=${eq.blizzard_item_id}" class="mcn-wh-link" target="_blank" rel="noopener noreferrer">
              <img class="mcn-gt__icon" src="${_gpEsc(eq.icon_url)}" alt="" loading="lazy"${iconBs}>
            </a>`
         : '';
@@ -1542,8 +1542,7 @@ function _gpRenderGearTable(slots, tc) {
       equippedHtml = `<div class="mcn-gt__item">
         ${icon}
         <div class="mcn-gt__item-info">
-          <a href="https://www.wowhead.com/item=${eq.blizzard_item_id}" target="_blank" rel="noopener noreferrer"
-             class="mcn-gt__name"${nameColor}>${_gpEsc(eq.item_name || 'Unknown')}</a>
+          <span class="mcn-gt__name"${nameColor}>${_gpEsc(eq.item_name || 'Unknown')}</span>
           <div class="mcn-gt__meta">
             ${eq.item_level ? `<span class="mcn-gt__ilvl">${eq.item_level}</span>` : ''}
             ${badge}
@@ -1570,14 +1569,13 @@ function _gpRenderGearTable(slots, tc) {
       const goalItem = desired || (bisRecs.length ? bisRecs[0] : null);
       if (goalItem && goalItem.blizzard_item_id) {
         const icon = goalItem.icon_url
-          ? `<a href="https://www.wowhead.com/item=${goalItem.blizzard_item_id}" target="_blank" rel="noopener noreferrer">
+          ? `<a href="https://www.wowhead.com/item=${goalItem.blizzard_item_id}" class="mcn-wh-link" target="_blank" rel="noopener noreferrer">
                <img class="mcn-gt__icon" src="${_gpEsc(goalItem.icon_url)}" alt="" loading="lazy">
              </a>`
           : '';
         goalHtml = `<div class="mcn-gt__item">
           ${icon}
-          <a href="https://www.wowhead.com/item=${goalItem.blizzard_item_id}" target="_blank" rel="noopener noreferrer"
-             class="mcn-gt__name">${_gpEsc(goalItem.item_name || goalItem.name || 'Unknown')}</a>
+          <span class="mcn-gt__name">${_gpEsc(goalItem.item_name || goalItem.name || 'Unknown')}</span>
         </div>`;
       } else {
         goalHtml = '<span class="mcn-gt__empty">&mdash;</span>';
@@ -2211,10 +2209,10 @@ function _gpRenderDrawerBody(slotKey, sd, tc) {
     const bs = qc && qc !== '#888' ? ` style="border-color:${qc};box-shadow:0 0 6px ${qc}80"` : '';
     const badge = eq.quality_track ? `<span class="mcn-track-pill" style="background:${_gpEsc(qc)}">${_gpEsc(eq.quality_track)}</span>` : '';
     equippedHtml = `<div class="mcn-drawer-item">
-      ${eq.icon_url ? `<img class="mcn-drawer-item__icon" src="${_gpEsc(eq.icon_url)}" alt="" loading="lazy"${bs}>` : ''}
+      ${eq.icon_url ? `<a href="https://www.wowhead.com/item=${eq.blizzard_item_id}" class="mcn-wh-link" target="_blank" rel="noopener noreferrer"><img class="mcn-drawer-item__icon" src="${_gpEsc(eq.icon_url)}" alt="" loading="lazy"${bs}></a>` : ''}
       <div class="mcn-drawer-item__info">
         <div class="mcn-drawer-item__name"${ns}>
-          <a href="https://www.wowhead.com/item=${eq.blizzard_item_id}" target="_blank" rel="noopener noreferrer" style="color:inherit;text-decoration:none">${_gpEsc(eq.item_name || 'Unknown')}</a>
+          ${_gpEsc(eq.item_name || 'Unknown')}
         </div>
         <div class="mcn-drawer-item__meta">${eq.item_level ? eq.item_level + '\u00a0' : ''}${badge}</div>
       </div>
@@ -2232,10 +2230,10 @@ function _gpRenderDrawerBody(slotKey, sd, tc) {
   if (desired && desired.blizzard_item_id) {
     const locked = desired.is_locked;
     goalHtml = `<div class="mcn-drawer-item" style="margin-bottom:0.5rem">
-      ${desired.icon_url ? `<img class="mcn-drawer-item__icon" src="${_gpEsc(desired.icon_url)}" alt="" loading="lazy">` : ''}
+      ${desired.icon_url ? `<a href="https://www.wowhead.com/item=${desired.blizzard_item_id}" class="mcn-wh-link" target="_blank" rel="noopener noreferrer"><img class="mcn-drawer-item__icon" src="${_gpEsc(desired.icon_url)}" alt="" loading="lazy"></a>` : ''}
       <div class="mcn-drawer-item__info">
         <div class="mcn-drawer-item__name">
-          <a href="https://www.wowhead.com/item=${desired.blizzard_item_id}" target="_blank" rel="noopener noreferrer" style="color:inherit;text-decoration:none">${_gpEsc(desired.item_name || 'Unknown')}</a>
+          ${_gpEsc(desired.item_name || 'Unknown')}
         </div>
       </div>
     </div>
@@ -2417,11 +2415,11 @@ function _gpRenderBisGrid(slotKey, bis, tc, primaryBid, dbSlot) {
         : `<td class="mcn-bis-grid__check mcn-bis-grid__check--no">&mdash;</td>`
     ).join('');
     const icon = item.icon
-      ? `<img class="mcn-bis-grid__icon" src="${_gpEsc(item.icon)}" alt="" loading="lazy">`
+      ? `<a href="https://www.wowhead.com/item=${item.bid}" class="mcn-wh-link" target="_blank" rel="noopener noreferrer"><img class="mcn-bis-grid__icon" src="${_gpEsc(item.icon)}" alt="" loading="lazy"></a>`
       : `<span class="mcn-bis-grid__icon-ph"></span>`;
     const nameEsc = _gpEsc(item.name).replace(/'/g, "&#39;");
     return `<tr>
-      <td class="mcn-bis-grid__name"><div class="mcn-bis-grid__name-inner">${icon}<a href="https://www.wowhead.com/item=${item.bid}" target="_blank" rel="noopener noreferrer" style="color:inherit;text-decoration:none">${_gpEsc(item.name)}</a></div></td>
+      <td class="mcn-bis-grid__name"><div class="mcn-bis-grid__name-inner">${icon}${_gpEsc(item.name)}</div></td>
       ${cells}
       <td class="mcn-bis-grid__action">
         <button class="btn btn-sm btn-secondary" type="button" style="padding:0.1rem 0.4rem;font-size:0.7rem" onclick="mcnGpSetDesiredItem('${_gpEsc(dbSlot)}',${item.bid})">Use</button>
@@ -2442,7 +2440,7 @@ function _gpRenderAvailItems(dbSlot, items, tc, status) {
 
   const rows = items.map(item => {
     const icon = item.icon_url
-      ? `<img class="mcn-bis-grid__icon" src="${_gpEsc(item.icon_url)}" alt="" loading="lazy">`
+      ? `<a href="https://www.wowhead.com/item=${item.blizzard_item_id}" class="mcn-wh-link" target="_blank" rel="noopener noreferrer"><img class="mcn-bis-grid__icon" src="${_gpEsc(item.icon_url)}" alt="" loading="lazy"></a>`
       : `<span class="mcn-bis-grid__icon-ph"></span>`;
 
     // Aggregate unique tracks across all sources, ordered V < C < H < M
@@ -2458,7 +2456,7 @@ function _gpRenderAvailItems(dbSlot, items, tc, status) {
       <td class="mcn-bis-grid__name">
         <div class="mcn-bis-grid__name-inner">
           ${icon}
-          <a href="https://www.wowhead.com/item=${item.blizzard_item_id}" target="_blank" rel="noopener noreferrer" style="color:inherit;text-decoration:none">${_gpEsc(item.name)}</a>
+          ${_gpEsc(item.name)}
         </div>
         ${instText ? `<div class="mcn-avail-item__inst">${_gpEsc(instText)}</div>` : ''}
       </td>
@@ -2484,13 +2482,13 @@ function _gpRenderExcludedItems(dbSlot, items) {
   if (!items || !items.length) return '';
   const rows = items.map(item => {
     const icon = item.icon_url
-      ? `<img class="mcn-bis-grid__icon" src="${_gpEsc(item.icon_url)}" alt="" loading="lazy" style="opacity:0.5">`
+      ? `<a href="https://www.wowhead.com/item=${item.blizzard_item_id}" class="mcn-wh-link" target="_blank" rel="noopener noreferrer" style="opacity:0.5"><img class="mcn-bis-grid__icon" src="${_gpEsc(item.icon_url)}" alt="" loading="lazy"></a>`
       : `<span class="mcn-bis-grid__icon-ph"></span>`;
     return `<tr>
       <td class="mcn-bis-grid__name">
         <div class="mcn-bis-grid__name-inner">
           ${icon}
-          <a href="https://www.wowhead.com/item=${item.blizzard_item_id}" target="_blank" rel="noopener noreferrer" style="color:inherit;text-decoration:none;opacity:0.5">${_gpEsc(item.name)}</a>
+          <span style="opacity:0.5">${_gpEsc(item.name)}</span>
         </div>
       </td>
       <td class="mcn-bis-grid__action">

--- a/src/guild_portal/static/js/my_characters.js
+++ b/src/guild_portal/static/js/my_characters.js
@@ -1119,6 +1119,18 @@ function _selectChar(charId) {
 // Refresh button (delegates to existing /api/v1/me/bnet-sync)
 // ---------------------------------------------------------------------------
 
+function _initSimcModal() {
+  document.getElementById('mcn-simc-close')  ?.addEventListener('click', _gpHideSimcModal);
+  document.getElementById('mcn-simc-cancel') ?.addEventListener('click', _gpHideSimcModal);
+  document.getElementById('mcn-simc-submit') ?.addEventListener('click', _gpOnSimcImport);
+  // Close on backdrop click
+  document.getElementById('mcn-simc-modal')?.addEventListener('click', e => {
+    if (e.target === e.currentTarget || e.target.classList.contains('mcn-modal__backdrop')) {
+      _gpHideSimcModal();
+    }
+  });
+}
+
 function _initRefreshButton() {
   const btn = document.getElementById("mcn-btn-refresh");
   if (!btn) return;
@@ -1182,6 +1194,7 @@ async function _init() {
     }
 
     _initRefreshButton();
+    _initSimcModal();
 
   } catch (err) {
     _hide("mcn-loading");
@@ -1238,6 +1251,18 @@ function _gpEsc(s) {
   return String(s)
     .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+
+function _gpTimeAgo(dateVal) {
+  if (!dateVal) return null;
+  const diff = Date.now() - new Date(dateVal).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins} min${mins !== 1 ? 's' : ''} ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs} hour${hrs !== 1 ? 's' : ''} ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days} day${days !== 1 ? 's' : ''} ago`;
 }
 
 async function _gpFetch(url, opts) {
@@ -1651,9 +1676,41 @@ function _gpRenderCenterPanel(data) {
     return `<optgroup label="${_gpEsc(groupLabel)}">${options}</optgroup>`;
   }).join('');
 
+  // ── Source toggle (Phase 1E.6) ──────────────────────────────────────────
+  const equippedSrc   = plan?.equipped_source || 'blizzard';
+  const isBlizzard    = equippedSrc === 'blizzard';
+  const isSimC        = equippedSrc === 'simc';
+  const simcAt        = plan?.simc_imported_at   ? new Date(plan.simc_imported_at)   : null;
+  const blizzardAt    = plan?.blizzard_synced_at ? new Date(plan.blizzard_synced_at) : null;
+  const simcAgeDays   = simcAt ? (Date.now() - simcAt.getTime()) / 86400000 : null;
+  const simcStale     = simcAgeDays !== null && simcAgeDays > 7;
+
+  const blizzTs = blizzardAt ? `<span class="mcn-gp-src-ts">Synced ${_gpTimeAgo(blizzardAt)}</span>` : '';
+  const simcTs  = simcAt     ? `<span class="mcn-gp-src-ts">Imported ${_gpTimeAgo(simcAt)}</span>`   :
+                               `<span class="mcn-gp-src-ts mcn-gp-src-ts--none">No SimC import yet</span>`;
+  const staleWarn = (isSimC && simcStale)
+    ? `<div class="mcn-gp-src-stale">&#9888; SimC data is ${Math.floor(simcAgeDays)} days old \u2014 consider re-importing</div>`
+    : '';
+
+  const sourceBar = `
+    <div class="mcn-gp-source-bar">
+      <div class="mcn-gp-source-pills">
+        <button class="mcn-gp-source-pill${isBlizzard ? ' is-active' : ''}"
+                onclick="_gpOnToggleSource('blizzard')" type="button">Blizzard API</button>
+        <button class="mcn-gp-source-pill${isSimC ? ' is-active' : ''}"
+                onclick="_gpOnToggleSource('simc')" type="button">SimC Import</button>
+      </div>
+      <div class="mcn-gp-source-meta">
+        ${isBlizzard ? blizzTs : simcTs}
+      </div>
+    </div>
+    ${staleWarn}
+  `;
+
   area.innerHTML = `
     <div id="mcn-gp-slot-detail" hidden></div>
     <div class="mcn-detail-area__heading">Gear Plan</div>
+    ${sourceBar}
     <div class="mcn-gear-controls">
       <div class="mcn-gear-ctrl-row">
         <label class="mcn-gear-label">BIS List</label>
@@ -1662,9 +1719,8 @@ function _gpRenderCenterPanel(data) {
         <label class="mcn-gear-label">Hero Talent</label>
         <select id="mcn-gp-ht-sel" class="mcn-gear-select">${htOpts}</select>` : ''}
         <button id="mcn-gp-btn-fill" class="btn btn-primary btn-sm" type="button">Fill BIS</button>
-        <!-- SimC hidden pending full testing — see reference/gear-plan-4-simc.md -->
-        <button id="mcn-gp-btn-import" class="btn btn-secondary btn-sm" type="button" style="display:none">Import SimC</button>
-        <button id="mcn-gp-btn-export" class="btn btn-secondary btn-sm" type="button" style="display:none">Export SimC</button>
+        <button id="mcn-gp-btn-import" class="btn btn-secondary btn-sm" type="button">Import SimC</button>
+        <button id="mcn-gp-btn-export" class="btn btn-secondary btn-sm" type="button">Export SimC</button>
       </div>
     </div>
     <div id="mcn-gp-status" class="mcn-gp-status" hidden></div>
@@ -1681,9 +1737,11 @@ function _gpRenderCenterPanel(data) {
   }
 
   // Wire selects + buttons
-  document.getElementById('mcn-gp-ht-sel')  ?.addEventListener('change', _gpOnConfigChange);
-  document.getElementById('mcn-gp-src-sel') ?.addEventListener('change', _gpOnConfigChange);
-  document.getElementById('mcn-gp-btn-fill')  ?.addEventListener('click', _gpOnPopulate);
+  document.getElementById('mcn-gp-ht-sel')    ?.addEventListener('change', _gpOnConfigChange);
+  document.getElementById('mcn-gp-src-sel')   ?.addEventListener('change', _gpOnConfigChange);
+  document.getElementById('mcn-gp-btn-fill')  ?.addEventListener('click',  _gpOnPopulate);
+  document.getElementById('mcn-gp-btn-import')?.addEventListener('click',  _gpShowSimcModal);
+  document.getElementById('mcn-gp-btn-export')?.addEventListener('click',  _gpOnExportSimc);
   // Wire drawer close
   const drawerClose = document.getElementById('mcn-gp-drawer-close');
   if (drawerClose && !drawerClose._gpWired) {
@@ -1881,6 +1939,33 @@ async function _gpOnExportSimc() {
     _gpClearStatus();
   } catch (err) {
     _gpShowStatus(err.message, 'err');
+  }
+}
+
+// ── Source toggle (Phase 1E.6) ─────────────────────────────────────────────────
+
+async function _gpOnToggleSource(source) {
+  const charId = _selectedChar?.id;
+  if (!charId) return;
+  // Optimistically switch; if no simc profile, show import modal instead
+  if (source === 'simc') {
+    const cached = _gpCache[charId];
+    const hasSimc = !!(cached?.plan?.simc_imported_at || cached?.plan?.simc_profile);
+    if (!hasSimc) {
+      _gpShowSimcModal();
+      return;
+    }
+  }
+  const resp = await _gpFetch(`/api/v1/me/gear-plan/${charId}/source`, {
+    method: 'PATCH',
+    body: JSON.stringify({ source }),
+  });
+  if (resp.ok) {
+    await _gpReload();
+  } else if (resp.error === 'No SimC profile imported yet \u2014 paste one first') {
+    _gpShowSimcModal();
+  } else {
+    _gpShowStatus(resp.error || 'Source switch failed', 'err');
   }
 }
 

--- a/src/guild_portal/static/js/my_characters.js
+++ b/src/guild_portal/static/js/my_characters.js
@@ -1108,6 +1108,10 @@ function _selectChar(charId) {
   const char = _chars.find(c => c.id === charId);
   if (!char) return;
   _selectedChar = char;
+  // Reset gear plan local state for new character
+  _gpEquippedTab = null;
+  _gpEquippedShowInput = false;
+  _gpBisTab = 'guide';
   _renderHeader(char);
   _renderGuides(char);
   _gpResetPaperdolls();   // reset to placeholder; gear loads on gear-tab activation
@@ -1119,17 +1123,7 @@ function _selectChar(charId) {
 // Refresh button (delegates to existing /api/v1/me/bnet-sync)
 // ---------------------------------------------------------------------------
 
-function _initSimcModal() {
-  document.getElementById('mcn-simc-close')  ?.addEventListener('click', _gpHideSimcModal);
-  document.getElementById('mcn-simc-cancel') ?.addEventListener('click', _gpHideSimcModal);
-  document.getElementById('mcn-simc-submit') ?.addEventListener('click', _gpOnSimcImport);
-  // Close on backdrop click
-  document.getElementById('mcn-simc-modal')?.addEventListener('click', e => {
-    if (e.target === e.currentTarget || e.target.classList.contains('mcn-modal__backdrop')) {
-      _gpHideSimcModal();
-    }
-  });
-}
+// _initSimcModal removed — SimC import is now inline in the gear plan sections
 
 function _initRefreshButton() {
   const btn = document.getElementById("mcn-btn-refresh");
@@ -1194,7 +1188,6 @@ async function _init() {
     }
 
     _initRefreshButton();
-    _initSimcModal();
 
   } catch (err) {
     _hide("mcn-loading");
@@ -1243,6 +1236,9 @@ const GP_TRACK_FALLBACK = { V: '#22c55e', C: '#3b82f6', H: '#a855f7', M: '#f9731
 const _gpCache = {};       // charId → API data (plan, slots, bisSources, heroTalents, trackColors)
 const _gpAvailCache = {};  // "charId:dbSlot" → { status: 'loading'|'done'|'error', items: [] }
 let _gpOpenSlot = null;
+let _gpEquippedTab = null;        // null = use plan.equipped_source; 'blizzard'|'simc' for local override
+let _gpEquippedShowInput = false; // show the SimC paste area in the equipped section
+let _gpBisTab = 'guide';          // 'current'|'guide'|'simc_bis'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -1647,6 +1643,65 @@ function _gpRenderCenterPanel(data) {
   const bisSources  = data.bis_sources  || [];
   const heroTalents = data.hero_talents || [];
 
+  // ── Equipped Gear Source section ────────────────────────────────────────
+  const serverSrc      = plan?.equipped_source || 'blizzard';
+  const effectiveEqTab = _gpEquippedTab ?? serverSrc;
+  const isEqBlizzard   = effectiveEqTab === 'blizzard';
+  const isEqSimC       = effectiveEqTab === 'simc';
+
+  const simcAt      = plan?.simc_imported_at   ? new Date(plan.simc_imported_at)   : null;
+  const blizzardAt  = plan?.blizzard_synced_at ? new Date(plan.blizzard_synced_at) : null;
+  const simcAgeDays = simcAt ? (Date.now() - simcAt.getTime()) / 86400000 : null;
+  const simcStale   = simcAgeDays !== null && simcAgeDays > 7;
+
+  // Blizzard panel content
+  const blizzardPanel = `
+    <div class="mcn-gp-panel" id="mcn-gp-panel-blizzard"${isEqBlizzard ? '' : ' hidden'}>
+      <div class="mcn-gp-sync-row">
+        ${blizzardAt
+          ? `<span class="mcn-gp-src-ts">Last synced ${_gpTimeAgo(blizzardAt)}</span>`
+          : `<span class="mcn-gp-src-ts mcn-gp-src-ts--none">Not yet synced</span>`}
+        <button id="mcn-gp-btn-sync" class="btn btn-secondary btn-sm" type="button">Sync Now</button>
+      </div>
+    </div>`;
+
+  // SimC equipped panel content — shows textarea if no import yet OR user clicked Re-import
+  const showSimcInput = isEqSimC && (_gpEquippedShowInput || !simcAt);
+  const simcPanel = `
+    <div class="mcn-gp-panel mcn-gp-panel--simc" id="mcn-gp-panel-simc"${isEqSimC ? '' : ' hidden'}>
+      ${showSimcInput ? `
+        <textarea id="mcn-gp-eq-simc-text" class="mcn-gp-textarea"
+                  placeholder="Paste SimC profile here\u2026" rows="6"></textarea>
+        <div class="mcn-gp-panel-actions">
+          <button id="mcn-gp-btn-import-eq" class="btn btn-primary btn-sm" type="button">Set as Equipped</button>
+          ${simcAt ? `<button id="mcn-gp-btn-cancel-eq" class="btn btn-secondary btn-sm" type="button">Cancel</button>` : ''}
+        </div>` : `
+        <div class="mcn-gp-sync-row">
+          <span class="mcn-gp-src-ts">Snapshot from ${_gpTimeAgo(simcAt)}</span>
+          <button id="mcn-gp-btn-reimport-eq" class="btn btn-secondary btn-sm" type="button">Re-import</button>
+        </div>
+        ${simcStale ? `<div class="mcn-gp-src-stale">&#9888; SimC data is ${Math.floor(simcAgeDays)} days old \u2014 consider re-importing</div>` : ''}`}
+    </div>`;
+
+  const equippedSection = `
+    <div class="mcn-gp-section">
+      <div class="mcn-gp-section__hdr">
+        <span class="mcn-gp-section__title">Equipped Gear Source</span>
+        <button id="mcn-gp-btn-export-eq" class="mcn-gp-section__export" title="Export equipped gear as SimC" type="button">&#11015;</button>
+      </div>
+      <div class="mcn-gp-section__tabs">
+        <button class="mcn-gp-stab${isEqBlizzard ? ' is-active' : ''}"
+                onclick="_gpOnEquippedTab('blizzard')" type="button">Blizzard API</button>
+        <button class="mcn-gp-stab${isEqSimC ? ' is-active' : ''}"
+                onclick="_gpOnEquippedTab('simc')" type="button">SimC Import</button>
+      </div>
+      ${blizzardPanel}
+      ${simcPanel}
+    </div>`;
+
+  // ── BIS Sourcing section ────────────────────────────────────────────────
+  const bisTab = _gpBisTab;
+
   const selectedSource = bisSources.find(s => s.id === plan?.bis_source_id) || bisSources[0];
   const showHtDropdown = !!(selectedSource?.has_hero_talent_variants && heroTalents.length > 0);
 
@@ -1655,10 +1710,9 @@ function _gpRenderCenterPanel(data) {
       `<option value="${ht.id}"${plan?.hero_talent_id === ht.id ? ' selected' : ''}>${_gpEsc(ht.name)}</option>`
     )).join('');
 
-  const ORIGIN_LABEL      = { archon: 'u.gg', wowhead: 'Wowhead', icy_veins: 'Icy Veins' };
+  const ORIGIN_LABEL       = { archon: 'u.gg', wowhead: 'Wowhead', icy_veins: 'Icy Veins' };
   const CONTENT_TYPE_LABEL = { raid: 'Raid', mythic_plus: 'M+', overall: 'All' };
   const CONTENT_TYPE_ORDER = { overall: 0, raid: 1, mythic_plus: 2 };
-  // Group sources by origin; within each group put All first
   const srcByOrigin = [];
   const seenOrigins = [];
   for (const s of (bisSources || [])) {
@@ -1676,42 +1730,13 @@ function _gpRenderCenterPanel(data) {
     return `<optgroup label="${_gpEsc(groupLabel)}">${options}</optgroup>`;
   }).join('');
 
-  // ── Source toggle (Phase 1E.6) ──────────────────────────────────────────
-  const equippedSrc   = plan?.equipped_source || 'blizzard';
-  const isBlizzard    = equippedSrc === 'blizzard';
-  const isSimC        = equippedSrc === 'simc';
-  const simcAt        = plan?.simc_imported_at   ? new Date(plan.simc_imported_at)   : null;
-  const blizzardAt    = plan?.blizzard_synced_at ? new Date(plan.blizzard_synced_at) : null;
-  const simcAgeDays   = simcAt ? (Date.now() - simcAt.getTime()) / 86400000 : null;
-  const simcStale     = simcAgeDays !== null && simcAgeDays > 7;
+  const bisCurrentPanel = `
+    <div class="mcn-gp-panel" id="mcn-gp-panel-bis-current"${bisTab === 'current' ? '' : ' hidden'}>
+      <p class="mcn-gp-blurb">Your BIS goals reflect your current equipped gear. Switch to <strong>Use a Guide</strong> to get upgrade recommendations, or <strong>Import SimC</strong> to paste a theorycrafter&#39;s profile.</p>
+    </div>`;
 
-  const blizzTs = blizzardAt ? `<span class="mcn-gp-src-ts">Synced ${_gpTimeAgo(blizzardAt)}</span>` : '';
-  const simcTs  = simcAt     ? `<span class="mcn-gp-src-ts">Imported ${_gpTimeAgo(simcAt)}</span>`   :
-                               `<span class="mcn-gp-src-ts mcn-gp-src-ts--none">No SimC import yet</span>`;
-  const staleWarn = (isSimC && simcStale)
-    ? `<div class="mcn-gp-src-stale">&#9888; SimC data is ${Math.floor(simcAgeDays)} days old \u2014 consider re-importing</div>`
-    : '';
-
-  const sourceBar = `
-    <div class="mcn-gp-source-bar">
-      <div class="mcn-gp-source-pills">
-        <button class="mcn-gp-source-pill${isBlizzard ? ' is-active' : ''}"
-                onclick="_gpOnToggleSource('blizzard')" type="button">Blizzard API</button>
-        <button class="mcn-gp-source-pill${isSimC ? ' is-active' : ''}"
-                onclick="_gpOnToggleSource('simc')" type="button">SimC Import</button>
-      </div>
-      <div class="mcn-gp-source-meta">
-        ${isBlizzard ? blizzTs : simcTs}
-      </div>
-    </div>
-    ${staleWarn}
-  `;
-
-  area.innerHTML = `
-    <div id="mcn-gp-slot-detail" hidden></div>
-    <div class="mcn-detail-area__heading">Gear Plan</div>
-    ${sourceBar}
-    <div class="mcn-gear-controls">
+  const bisGuidePanel = `
+    <div class="mcn-gp-panel" id="mcn-gp-panel-bis-guide"${bisTab === 'guide' ? '' : ' hidden'}>
       <div class="mcn-gear-ctrl-row">
         <label class="mcn-gear-label">BIS List</label>
         <select id="mcn-gp-src-sel" class="mcn-gear-select">${srcOpts}</select>
@@ -1719,9 +1744,43 @@ function _gpRenderCenterPanel(data) {
         <label class="mcn-gear-label">Hero Talent</label>
         <select id="mcn-gp-ht-sel" class="mcn-gear-select">${htOpts}</select>` : ''}
         <button id="mcn-gp-btn-fill" class="btn btn-primary btn-sm" type="button">Fill BIS</button>
-        <button id="mcn-gp-btn-import" class="btn btn-secondary btn-sm" type="button">Import SimC</button>
-        <button id="mcn-gp-btn-export" class="btn btn-secondary btn-sm" type="button">Export SimC</button>
       </div>
+    </div>`;
+
+  const bisSimcPanel = `
+    <div class="mcn-gp-panel mcn-gp-panel--simc" id="mcn-gp-panel-bis-simc"${bisTab === 'simc_bis' ? '' : ' hidden'}>
+      <textarea id="mcn-gp-bis-simc-text" class="mcn-gp-textarea"
+                placeholder="Paste SimC profile here\u2026 Your BIS goals will be set to the items in the profile." rows="6"></textarea>
+      <div class="mcn-gp-panel-actions">
+        <button id="mcn-gp-btn-import-bis" class="btn btn-primary btn-sm" type="button">Set as BIS Goals</button>
+      </div>
+    </div>`;
+
+  const bisSection = `
+    <div class="mcn-gp-section">
+      <div class="mcn-gp-section__hdr">
+        <span class="mcn-gp-section__title">BIS Sourcing</span>
+        <button id="mcn-gp-btn-export-bis" class="mcn-gp-section__export" title="Export BIS goals as SimC" type="button">&#11015;</button>
+      </div>
+      <div class="mcn-gp-section__tabs">
+        <button class="mcn-gp-stab${bisTab === 'current'  ? ' is-active' : ''}"
+                onclick="_gpOnBisTab('current')"  type="button">My Current Gear</button>
+        <button class="mcn-gp-stab${bisTab === 'guide'    ? ' is-active' : ''}"
+                onclick="_gpOnBisTab('guide')"    type="button">Use a Guide</button>
+        <button class="mcn-gp-stab${bisTab === 'simc_bis' ? ' is-active' : ''}"
+                onclick="_gpOnBisTab('simc_bis')" type="button">Import SimC</button>
+      </div>
+      ${bisCurrentPanel}
+      ${bisGuidePanel}
+      ${bisSimcPanel}
+    </div>`;
+
+  area.innerHTML = `
+    <div id="mcn-gp-slot-detail" hidden></div>
+    <div class="mcn-detail-area__heading">Gear Plan</div>
+    <div class="mcn-gp-sections">
+      ${equippedSection}
+      ${bisSection}
     </div>
     <div id="mcn-gp-status" class="mcn-gp-status" hidden></div>
     ${_gpRenderGearTable(data.slots, data.track_colors)}
@@ -1736,12 +1795,20 @@ function _gpRenderCenterPanel(data) {
     });
   }
 
-  // Wire selects + buttons
-  document.getElementById('mcn-gp-ht-sel')    ?.addEventListener('change', _gpOnConfigChange);
-  document.getElementById('mcn-gp-src-sel')   ?.addEventListener('change', _gpOnConfigChange);
-  document.getElementById('mcn-gp-btn-fill')  ?.addEventListener('click',  _gpOnPopulate);
-  document.getElementById('mcn-gp-btn-import')?.addEventListener('click',  _gpShowSimcModal);
-  document.getElementById('mcn-gp-btn-export')?.addEventListener('click',  _gpOnExportSimc);
+  // Wire Equipped section
+  document.getElementById('mcn-gp-btn-sync')       ?.addEventListener('click', _gpOnSyncGear);
+  document.getElementById('mcn-gp-btn-import-eq')  ?.addEventListener('click', _gpOnImportEquipped);
+  document.getElementById('mcn-gp-btn-cancel-eq')  ?.addEventListener('click', _gpCancelSimcInput);
+  document.getElementById('mcn-gp-btn-reimport-eq')?.addEventListener('click', _gpStartSimcReimport);
+  document.getElementById('mcn-gp-btn-export-eq')  ?.addEventListener('click', _gpOnExportEquipped);
+
+  // Wire BIS section
+  document.getElementById('mcn-gp-ht-sel')          ?.addEventListener('change', _gpOnConfigChange);
+  document.getElementById('mcn-gp-src-sel')          ?.addEventListener('change', _gpOnConfigChange);
+  document.getElementById('mcn-gp-btn-fill')         ?.addEventListener('click',  _gpOnPopulate);
+  document.getElementById('mcn-gp-btn-import-bis')   ?.addEventListener('click',  _gpOnImportBisSimc);
+  document.getElementById('mcn-gp-btn-export-bis')   ?.addEventListener('click',  _gpOnExportSimc);
+
   // Wire drawer close
   const drawerClose = document.getElementById('mcn-gp-drawer-close');
   if (drawerClose && !drawerClose._gpWired) {
@@ -1918,6 +1985,15 @@ async function _gpOnDeletePlan() {
   }
 }
 
+function _gpDownloadText(text, filename) {
+  const a = Object.assign(document.createElement('a'), {
+    href: URL.createObjectURL(new Blob([text], { type: 'text/plain' })),
+    download: filename,
+  });
+  a.click();
+  URL.revokeObjectURL(a.href);
+}
+
 async function _gpOnExportSimc() {
   const charId = _selectedChar?.id;
   if (!charId) return;
@@ -1929,65 +2005,92 @@ async function _gpOnExportSimc() {
       _gpShowStatus(d.error || 'Export failed', 'err');
       return;
     }
-    const text = await resp.text();
-    const a = Object.assign(document.createElement('a'), {
-      href: URL.createObjectURL(new Blob([text], { type: 'text/plain' })),
-      download: 'gear_plan.simc',
-    });
-    a.click();
-    URL.revokeObjectURL(a.href);
+    _gpDownloadText(await resp.text(), 'gear_plan.simc');
     _gpClearStatus();
   } catch (err) {
     _gpShowStatus(err.message, 'err');
   }
 }
 
-// ── Source toggle (Phase 1E.6) ─────────────────────────────────────────────────
+// ── Equipped section handlers (Phase 1E.6 redesign) ───────────────────────────
 
-async function _gpOnToggleSource(source) {
+function _gpOnEquippedTab(tab) {
   const charId = _selectedChar?.id;
   if (!charId) return;
-  // Optimistically switch; if no simc profile, show import modal instead
-  if (source === 'simc') {
-    const cached = _gpCache[charId];
-    const hasSimc = !!(cached?.plan?.simc_imported_at || cached?.plan?.simc_profile);
-    if (!hasSimc) {
-      _gpShowSimcModal();
-      return;
+  const cached = _gpCache[charId];
+  const serverSrc = cached?.plan?.equipped_source || 'blizzard';
+
+  if (tab === 'simc') {
+    // Show SimC panel locally; no server call until user submits
+    _gpEquippedTab = 'simc';
+    const hasImport = !!(cached?.plan?.simc_imported_at);
+    _gpEquippedShowInput = !hasImport;
+    if (cached) _gpRenderCenterPanel(cached);
+  } else {
+    // Switching to Blizzard: if server is already on blizzard, just local redraw
+    _gpEquippedTab = 'blizzard';
+    _gpEquippedShowInput = false;
+    if (serverSrc === 'simc') {
+      // Need to commit the switch to server
+      _gpFetch(`/api/v1/me/gear-plan/${charId}/source`, {
+        method: 'PATCH',
+        body: JSON.stringify({ source: 'blizzard' }),
+      }).then(resp => {
+        if (resp.ok) { _gpReload(); }
+        else _gpShowStatus(resp.error || 'Source switch failed', 'err');
+      });
+    } else if (cached) {
+      _gpRenderCenterPanel(cached);
     }
   }
-  const resp = await _gpFetch(`/api/v1/me/gear-plan/${charId}/source`, {
-    method: 'PATCH',
-    body: JSON.stringify({ source }),
+}
+
+function _gpOnBisTab(tab) {
+  _gpBisTab = tab;
+  const charId = _selectedChar?.id;
+  const cached = charId ? _gpCache[charId] : null;
+  if (cached) _gpRenderCenterPanel(cached);
+}
+
+function _gpStartSimcReimport() {
+  _gpEquippedShowInput = true;
+  const charId = _selectedChar?.id;
+  const cached = charId ? _gpCache[charId] : null;
+  if (cached) _gpRenderCenterPanel(cached);
+}
+
+function _gpCancelSimcInput() {
+  _gpEquippedShowInput = false;
+  const charId = _selectedChar?.id;
+  const cached = charId ? _gpCache[charId] : null;
+  if (cached) _gpRenderCenterPanel(cached);
+}
+
+async function _gpOnImportEquipped() {
+  const textarea = document.getElementById('mcn-gp-eq-simc-text');
+  const text = textarea?.value?.trim();
+  if (!text) { _gpShowStatus('Paste a SimC profile first', 'err'); return; }
+  const charId = _selectedChar?.id;
+  if (!charId) return;
+  _gpShowStatus('Importing\u2026', 'info');
+  const resp = await _gpFetch(`/api/v1/me/gear-plan/${charId}/import-equipped-simc`, {
+    method: 'POST',
+    body: JSON.stringify({ simc_text: text }),
   });
   if (resp.ok) {
+    _gpEquippedTab = 'simc';
+    _gpEquippedShowInput = false;
+    _gpShowStatus('Equipped gear updated from SimC', 'ok');
     await _gpReload();
-  } else if (resp.error === 'No SimC profile imported yet \u2014 paste one first') {
-    _gpShowSimcModal();
   } else {
-    _gpShowStatus(resp.error || 'Source switch failed', 'err');
+    _gpShowStatus(resp.error || 'Import failed', 'err');
   }
 }
 
-// ── SimC modal ─────────────────────────────────────────────────────────────────
-
-function _gpShowSimcModal() {
-  const modal    = document.getElementById('mcn-simc-modal');
-  const textarea = document.getElementById('mcn-simc-text');
-  if (modal)    modal.hidden = false;
-  if (textarea) { textarea.value = ''; textarea.focus(); }
-}
-
-function _gpHideSimcModal() {
-  const modal = document.getElementById('mcn-simc-modal');
-  if (modal) modal.hidden = true;
-}
-
-async function _gpOnSimcImport() {
-  const textarea = document.getElementById('mcn-simc-text');
+async function _gpOnImportBisSimc() {
+  const textarea = document.getElementById('mcn-gp-bis-simc-text');
   const text = textarea?.value?.trim();
-  if (!text) return;
-  _gpHideSimcModal();
+  if (!text) { _gpShowStatus('Paste a SimC profile first', 'err'); return; }
   const charId = _selectedChar?.id;
   if (!charId) return;
   _gpShowStatus('Importing\u2026', 'info');
@@ -1997,11 +2100,21 @@ async function _gpOnSimcImport() {
   });
   if (resp.ok) {
     const d = resp.data || {};
-    _gpShowStatus(`Imported: ${d.populated || 0} slots set${d.skipped_locked ? `, ${d.skipped_locked} locked skipped` : ''}`, 'ok');
+    _gpShowStatus(`BIS goals set: ${d.populated || 0} slots${d.skipped_locked ? `, ${d.skipped_locked} locked skipped` : ''}`, 'ok');
+    _gpBisTab = 'guide';  // Switch to guide view to see the results
     await _gpReload();
   } else {
     _gpShowStatus(resp.error || 'Import failed', 'err');
   }
+}
+
+async function _gpOnExportEquipped() {
+  const charId = _selectedChar?.id;
+  if (!charId) return;
+  const resp = await fetch(`/api/v1/me/gear-plan/${charId}/export-equipped-simc`);
+  if (!resp.ok) { _gpShowStatus('No equipped gear data to export', 'err'); return; }
+  const text = await resp.text();
+  _gpDownloadText(text, 'equipped_gear.simc');
 }
 
 // ── Slot drawer ────────────────────────────────────────────────────────────────

--- a/src/guild_portal/templates/member/my_characters.html
+++ b/src/guild_portal/templates/member/my_characters.html
@@ -2,7 +2,7 @@
 {% block title %}My Characters — {{ site().guild_name }}{% endblock %}
 
 {% block head %}
-<link rel="stylesheet" href="/static/css/my_characters.css?v=1.6.0">
+<link rel="stylesheet" href="/static/css/my_characters.css?v=1.7.0">
 {% endblock %}
 
 {% block content %}
@@ -130,5 +130,5 @@
 {% block scripts %}
 <script>var whTooltips = {colorLinks: true, iconizeLinks: false, renameLinks: false, hide: {sellprice: true, ilvl: false, reqlevel: false, power: false}};</script>
 <script src="https://wow.zamimg.com/widgets/power.js"></script>
-<script src="/static/js/my_characters.js?v=1.9.0"></script>
+<script src="/static/js/my_characters.js?v=2.0.0"></script>
 {% endblock %}

--- a/src/guild_portal/templates/member/my_characters.html
+++ b/src/guild_portal/templates/member/my_characters.html
@@ -130,5 +130,5 @@
 {% block scripts %}
 <script>var whTooltips = {colorLinks: true, iconizeLinks: false, renameLinks: false, hide: {sellprice: true, ilvl: false, reqlevel: false, power: false}};</script>
 <script src="https://wow.zamimg.com/widgets/power.js"></script>
-<script src="/static/js/my_characters.js?v=2.0.0"></script>
+<script src="/static/js/my_characters.js?v=2.1.0"></script>
 {% endblock %}

--- a/src/guild_portal/templates/member/my_characters.html
+++ b/src/guild_portal/templates/member/my_characters.html
@@ -2,7 +2,7 @@
 {% block title %}My Characters — {{ site().guild_name }}{% endblock %}
 
 {% block head %}
-<link rel="stylesheet" href="/static/css/my_characters.css?v=1.5.0">
+<link rel="stylesheet" href="/static/css/my_characters.css?v=1.6.0">
 {% endblock %}
 
 {% block content %}
@@ -125,35 +125,10 @@
 
 </div>{# end .mcn-page #}
 
-{# ── SimC Import Modal — Phase 1E.6 ──────────────────────────────────────── #}
-<div id="mcn-simc-modal" class="mcn-modal" hidden>
-  <div class="mcn-modal__backdrop"></div>
-  <div class="mcn-modal__box">
-    <div class="mcn-modal__header">
-      <h3 class="mcn-modal__title">Import SimC Profile</h3>
-      <button id="mcn-simc-close" class="mcn-modal__close" type="button">&times;</button>
-    </div>
-    <div class="mcn-modal__body">
-      <p class="mcn-modal__hint">
-        Paste your SimC string from the in-game <strong>SimulationCraft</strong> addon
-        (<code>/simc</code> in WoW chat), or from
-        <a href="https://archon.gg" target="_blank" rel="noopener">Archon</a> /
-        <a href="https://www.wowhead.com" target="_blank" rel="noopener">Wowhead</a>.
-        Your paperdoll will switch to show SimC gear. Locked slots are not overwritten.
-      </p>
-      <textarea id="mcn-simc-text" class="mcn-simc-textarea"
-                placeholder="Paste SimC profile here&hellip;" rows="12"></textarea>
-    </div>
-    <div class="mcn-modal__footer">
-      <button id="mcn-simc-submit" class="btn btn-primary" type="button">Import &amp; Switch to SimC</button>
-      <button id="mcn-simc-cancel" class="btn btn-secondary" type="button">Cancel</button>
-    </div>
-  </div>
-</div>
 {% endblock %}
 
 {% block scripts %}
 <script>var whTooltips = {colorLinks: true, iconizeLinks: false, renameLinks: false, hide: {sellprice: true, ilvl: false, reqlevel: false, power: false}};</script>
 <script src="https://wow.zamimg.com/widgets/power.js"></script>
-<script src="/static/js/my_characters.js?v=1.8.0"></script>
+<script src="/static/js/my_characters.js?v=1.9.0"></script>
 {% endblock %}

--- a/src/guild_portal/templates/member/my_characters.html
+++ b/src/guild_portal/templates/member/my_characters.html
@@ -2,7 +2,7 @@
 {% block title %}My Characters — {{ site().guild_name }}{% endblock %}
 
 {% block head %}
-<link rel="stylesheet" href="/static/css/my_characters.css?v=1.7.0">
+<link rel="stylesheet" href="/static/css/my_characters.css?v=1.8.0">
 {% endblock %}
 
 {% block content %}

--- a/src/guild_portal/templates/member/my_characters.html
+++ b/src/guild_portal/templates/member/my_characters.html
@@ -2,7 +2,7 @@
 {% block title %}My Characters — {{ site().guild_name }}{% endblock %}
 
 {% block head %}
-<link rel="stylesheet" href="/static/css/my_characters.css?v=1.8.0">
+<link rel="stylesheet" href="/static/css/my_characters.css?v=1.9.0">
 {% endblock %}
 
 {% block content %}
@@ -130,5 +130,5 @@
 {% block scripts %}
 <script>var whTooltips = {colorLinks: true, iconizeLinks: false, renameLinks: false, hide: {sellprice: true, ilvl: false, reqlevel: false, power: false}};</script>
 <script src="https://wow.zamimg.com/widgets/power.js"></script>
-<script src="/static/js/my_characters.js?v=2.1.0"></script>
+<script src="/static/js/my_characters.js?v=2.2.0"></script>
 {% endblock %}

--- a/src/guild_portal/templates/member/my_characters.html
+++ b/src/guild_portal/templates/member/my_characters.html
@@ -2,7 +2,7 @@
 {% block title %}My Characters — {{ site().guild_name }}{% endblock %}
 
 {% block head %}
-<link rel="stylesheet" href="/static/css/my_characters.css?v=1.4.0">
+<link rel="stylesheet" href="/static/css/my_characters.css?v=1.5.0">
 {% endblock %}
 
 {% block content %}
@@ -125,8 +125,7 @@
 
 </div>{# end .mcn-page #}
 
-{# ── SimC Import Modal — Phase UI-1C ─────────────────────────────────────── #}
-{# SimC hidden pending full testing — see reference/gear-plan-4-simc.md
+{# ── SimC Import Modal — Phase 1E.6 ──────────────────────────────────────── #}
 <div id="mcn-simc-modal" class="mcn-modal" hidden>
   <div class="mcn-modal__backdrop"></div>
   <div class="mcn-modal__box">
@@ -136,25 +135,25 @@
     </div>
     <div class="mcn-modal__body">
       <p class="mcn-modal__hint">
-        Paste your SimC profile from the in-game SimulationCraft addon,
-        <a href="https://archon.gg" target="_blank" rel="noopener">Archon</a>, or
+        Paste your SimC string from the in-game <strong>SimulationCraft</strong> addon
+        (<code>/simc</code> in WoW chat), or from
+        <a href="https://archon.gg" target="_blank" rel="noopener">Archon</a> /
         <a href="https://www.wowhead.com" target="_blank" rel="noopener">Wowhead</a>.
-        Locked slots will not be overwritten.
+        Your paperdoll will switch to show SimC gear. Locked slots are not overwritten.
       </p>
       <textarea id="mcn-simc-text" class="mcn-simc-textarea"
                 placeholder="Paste SimC profile here&hellip;" rows="12"></textarea>
     </div>
     <div class="mcn-modal__footer">
-      <button id="mcn-simc-submit" class="btn btn-primary" type="button">Import</button>
+      <button id="mcn-simc-submit" class="btn btn-primary" type="button">Import &amp; Switch to SimC</button>
       <button id="mcn-simc-cancel" class="btn btn-secondary" type="button">Cancel</button>
     </div>
   </div>
 </div>
-#}
 {% endblock %}
 
 {% block scripts %}
 <script>var whTooltips = {colorLinks: true, iconizeLinks: false, renameLinks: false, hide: {sellprice: true, ilvl: false, reqlevel: false, power: false}};</script>
 <script src="https://wow.zamimg.com/widgets/power.js"></script>
-<script src="/static/js/my_characters.js?v=1.7.0"></script>
+<script src="/static/js/my_characters.js?v=1.8.0"></script>
 {% endblock %}

--- a/src/sv_common/db/models.py
+++ b/src/sv_common/db/models.py
@@ -1741,6 +1741,12 @@ class GearPlan(Base):
         Integer, ForeignKey("guild_identity.bis_list_sources.id", ondelete="SET NULL")
     )
     simc_profile: Mapped[Optional[str]] = mapped_column(Text)
+    simc_imported_at: Mapped[Optional[datetime]] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+    equipped_source: Mapped[str] = mapped_column(
+        String(10), nullable=False, server_default="blizzard"
+    )
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="true")
     created_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True), server_default=func.now()

--- a/src/sv_common/guild_sync/quality_track.py
+++ b/src/sv_common/guild_sync/quality_track.py
@@ -36,11 +36,16 @@ _DISPLAY_MAP_BARE = {
 # SimC bonus ID → quality track.
 # TWW Season 2 IDs kept for backward compat; Midnight IDs appended.
 # Admin can override via site_config key "simc_track_bonus_ids".
+#
+# Crafted-quality IDs (13621, 13622) are included here because they ARE
+# quality-discriminating bonus IDs, just sourced from crests rather than
+# upgrade tokens.  They're detected empirically via get_item_preview() during
+# equipment sync (see _CRAFTED_TRACK_IDS below for discovery notes).
 _DEFAULT_SIMC_BONUS_IDS: dict[str, list[int]] = {
     "V": [1498, 1499],
-    "C": [1516, 1517, 1518, 12790, 12795],  # TWW S2 + Midnight base/normal
-    "H": [1520, 1521, 1522, 12798, 12801],  # TWW S2 + Midnight heroic/M+
-    "M": [1524, 1525, 1526],
+    "C": [1516, 1517, 1518, 12790, 12795],           # TWW S2 + Midnight base/normal
+    "H": [1520, 1521, 1522, 12798, 12801, 13621],    # TWW S2 + Midnight heroic/M+ + Midnight crafted H
+    "M": [1524, 1525, 1526, 13622],                  # TWW S2 + Midnight crafted M
 }
 
 

--- a/tests/unit/test_quality_track.py
+++ b/tests/unit/test_quality_track.py
@@ -72,6 +72,18 @@ class TestTrackFromBonusIds:
         assert track_from_bonus_ids([9001], custom_map=custom) == "C"
         assert track_from_bonus_ids([1517], custom_map=custom) is None
 
+    def test_midnight_crafted_hero_track(self):
+        # 13621 = Midnight crafted H quality (discovered from Aetherlume Bands + back)
+        assert track_from_bonus_ids([13621]) == "H"
+
+    def test_midnight_crafted_mythic_track(self):
+        # 13622 = Midnight crafted M quality (discovered from Loa Worshiper's Band)
+        assert track_from_bonus_ids([13622]) == "M"
+
+    def test_midnight_crafted_mixed_bonus_ids(self):
+        # Crafted items have additional bonus IDs alongside the quality marker
+        assert track_from_bonus_ids([12214, 13621, 5000]) == "H"
+
 
 class TestDetectQualityTrack:
     def test_prefers_display_string(self):

--- a/tests/unit/test_simc_parser.py
+++ b/tests/unit/test_simc_parser.py
@@ -170,6 +170,16 @@ class TestParseGearSlots:
         slots = parse_gear_slots("head=helm,id=100,bonus_id=4800:1524")
         assert slots[0].quality_track == "M"
 
+    def test_midnight_crafted_hero_track(self):
+        # 13621 = Midnight crafted H — wrist/back crafted pieces
+        slots = parse_gear_slots("wrists=aetherlume_bands,id=225300,bonus_id=12214:13621:5000")
+        assert slots[0].quality_track == "H"
+
+    def test_midnight_crafted_mythic_track(self):
+        # 13622 = Midnight crafted M — ring crafted pieces
+        slots = parse_gear_slots("finger2=loa_worshipers_band,id=225310,bonus_id=12214:13622:5000")
+        assert slots[0].quality_track == "M"
+
 
 # ---------------------------------------------------------------------------
 # parse_profile


### PR DESCRIPTION
## Summary

- **Migration 0094**: `gear_plans.simc_imported_at TIMESTAMPTZ` + `equipped_source VARCHAR(10) DEFAULT 'blizzard'`
- **Two-section gear plan UI**: Equipped Gear Source (Blizzard API / Import SimC) + BIS Sourcing (My Current Gear / Use a Guide / Import SimC) with status indicator dots and download buttons
- **SimC persistence**: store/display/export the SimC profile; switching back to Blizzard and returning restores it
- **Set Goals to Current Gear**: new button + endpoint copies `character_equipment` into unlocked `gear_plan_slots` as a BIS baseline
- **Crafted quality track fix**: add Midnight crafted bonus IDs (13621→H, 13622→M) to `_DEFAULT_SIMC_BONUS_IDS` so wrist/back/ring crafted pieces show correct quality from SimC
- **Layout**: 40/60 flex split, blurb text wrapping, Wowhead popup on icons (not names), flat name text, equipped column name wrapping

## Test plan

- [ ] Gear tab loads with two sections visible, each filling their share of the row
- [ ] Blizzard API tab shows sync timestamp dot (green/amber/red based on age)
- [ ] Import SimC tab: paste a SimC profile → "Set as Equipped" stores it; returning to this tab shows the snapshot timestamp, not the textarea
- [ ] Switch back to Blizzard API → then back to Import SimC → stored profile still there, no re-paste needed
- [ ] Download buttons on each section header produce correct `.simc` files
- [ ] My Current Gear → "Set Goals to Current Gear" → slots populate from equipped gear, view switches to Use a Guide tab
- [ ] Crafted pieces (wrist, back, ring) show correct H/M quality track from SimC profile
- [ ] Hover an item icon → Wowhead popup appears; item name is plain text with no link/popup
- [ ] Long item names wrap in the Equipped column (no ellipsis truncation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)