### PR TITLE
fix: right-aligned FAQ link in Gear Plan heading

### DIFF
--- a/src/guild_portal/static/css/my_characters.css
+++ b/src/guild_portal/static/css/my_characters.css
@@ -2201,7 +2201,23 @@ details[open].mcn-avail-section > .mcn-avail-section__toggle::before {
   padding: 0.25rem 0.5rem;
 }
 
-/* ── Phase 1E.7: Tour button ─────────────────────────────────────────────── */
+/* ── Phase 1E.7: Tour button + FAQ link ──────────────────────────────────── */
+
+.mcn-gp-faq-link {
+  margin-left: auto;
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  color: var(--color-accent);
+  text-decoration: none;
+  opacity: 0.75;
+  transition: opacity 0.15s;
+}
+
+.mcn-gp-faq-link:hover {
+  opacity: 1;
+  text-decoration: underline;
+}
 
 .mcn-gp-tour-btn {
   display: inline-flex;

--- a/src/guild_portal/static/js/my_characters.js
+++ b/src/guild_portal/static/js/my_characters.js
@@ -1801,6 +1801,7 @@ function _gpRenderCenterPanel(data) {
     <div class="mcn-detail-area__heading">
       Gear Plan
       <button id="mcn-gp-tour-btn" class="mcn-gp-tour-btn" type="button" title="Take a guided tour of the gear plan">?</button>
+      <a href="#mcn-gp-faq" class="mcn-gp-faq-link">FAQ &#x2193;</a>
     </div>
     <div class="mcn-gp-sections">
       ${equippedSection}
@@ -2762,7 +2763,7 @@ function _gpRenderFaq() {
       <div class="mcn-faq-a">${a}</div>
     </details>`).join('');
 
-  return `<div class="mcn-gp-faq">
+  return `<div class="mcn-gp-faq" id="mcn-gp-faq">
     <div class="mcn-gp-faq__hdr">Frequently Asked Questions</div>
     ${items}
   </div>`;

--- a/src/guild_portal/templates/member/my_characters.html
+++ b/src/guild_portal/templates/member/my_characters.html
@@ -3,7 +3,7 @@
 
 {% block head %}
 <link rel="stylesheet" href="/static/css/vendor/shepherd.css">
-<link rel="stylesheet" href="/static/css/my_characters.css?v=2.0.0">
+<link rel="stylesheet" href="/static/css/my_characters.css?v=2.0.1">
 {% endblock %}
 
 {% block content %}
@@ -132,5 +132,5 @@
 <script>var whTooltips = {colorLinks: true, iconizeLinks: false, renameLinks: false, hide: {sellprice: true, ilvl: false, reqlevel: false, power: false}};</script>
 <script src="https://wow.zamimg.com/widgets/power.js"></script>
 <script src="/static/js/vendor/shepherd.min.js"></script>
-<script src="/static/js/my_characters.js?v=2.3.0"></script>
+<script src="/static/js/my_characters.js?v=2.3.1"></script>
 {% endblock %}


### PR DESCRIPTION
Adds an FAQ ↓ anchor link right-aligned in the Gear Plan heading bar, alongside the existing ? tour button. Clicking it scrolls to the FAQ accordion at the bottom of the tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)