### PR TITLE
fix: catalyst tier Pass 1 fallback for pre-Wowhead-index expansion items

### DIFF
--- a/src/sv_common/guild_sync/item_source_sync.py
+++ b/src/sv_common/guild_sync/item_source_sync.py
@@ -669,9 +669,12 @@ async def enrich_catalyst_tier_items(
         )
 
         # ── Pass 1: all tier slots (main-5 + catalyst) with item-set tooltip link ──
-        # Catalyst-slot pieces (back/wrist/waist/feet) that Wowhead has already
-        # indexed will have /item-set=N/ links in their tooltip HTML, even though
-        # they never appear in the Blizzard Journal.  Query all 9 slots.
+        # PRIMARY: Wowhead tooltip has /item-set=/ link — definitive tier marker.
+        # FALLBACK: Wowhead not yet indexed for this expansion.  Detect by:
+        #   armor_type IS NOT NULL + no existing item_sources + in BIS lists.
+        #   This matches Midnight tier pieces on first-sync prod where Wowhead pages
+        #   don't exist yet (e.g., "Trunk of the Luminous Bloom" exists only from BIS
+        #   scraping, has no tooltip, and no boss sources — catalyst gives it).
         all_tier_slots = list(_TIER_SLOTS | _CATALYST_SLOTS)
         tier_items = await conn.fetch(
             """
@@ -680,7 +683,27 @@ async def enrich_catalyst_tier_items(
               FROM guild_identity.bis_list_entries ble
               JOIN guild_identity.wow_items wi ON wi.id = ble.item_id
              WHERE ble.slot = ANY($1::text[])
-               AND wi.wowhead_tooltip_html LIKE '%/item-set=%'
+               AND (
+                   -- PRIMARY: Wowhead tooltip confirms tier set membership.
+                   wi.wowhead_tooltip_html LIKE '%/item-set=%'
+                   OR
+                   -- FALLBACK: No Wowhead page yet (new expansion).
+                   --   Item must have armor_type (enriched via Blizzard API) and
+                   --   no existing boss sources (if it already has sources it's a
+                   --   regular drop, not a catalyst-only piece).
+                   --   Crafted items are excluded — they have item_recipe_links
+                   --   rather than item_sources and must not get raid boss rows.
+                   (    wi.armor_type IS NOT NULL
+                    AND NOT EXISTS (
+                            SELECT 1 FROM guild_identity.item_sources s
+                             WHERE s.item_id = wi.id
+                        )
+                    AND NOT EXISTS (
+                            SELECT 1 FROM guild_identity.item_recipe_links irl
+                             WHERE irl.item_id = wi.id
+                        )
+                   )
+               )
             """,
             all_tier_slots,
         )

--- a/src/sv_common/guild_sync/item_source_sync.py
+++ b/src/sv_common/guild_sync/item_source_sync.py
@@ -688,12 +688,14 @@ async def enrich_catalyst_tier_items(
                    wi.wowhead_tooltip_html LIKE '%/item-set=%'
                    OR
                    -- FALLBACK: No Wowhead page yet (new expansion).
-                   --   Item must have armor_type (enriched via Blizzard API) and
-                   --   no existing boss sources (if it already has sources it's a
-                   --   regular drop, not a catalyst-only piece).
-                   --   Crafted items are excluded — they have item_recipe_links
-                   --   rather than item_sources and must not get raid boss rows.
+                   --   Restricted to items with "of the X" suffix naming — the
+                   --   convention used by leather/mail Midnight tier pieces.
+                   --   Cloth/plate tier pieces use different names but have Wowhead
+                   --   pages, so they're caught by PRIMARY above.
+                   --   Also excludes crafted items (item_recipe_links) and items
+                   --   that already have boss sources.
                    (    wi.armor_type IS NOT NULL
+                    AND wi.name LIKE '% of %'
                     AND NOT EXISTS (
                             SELECT 1 FROM guild_identity.item_sources s
                              WHERE s.item_id = wi.id


### PR DESCRIPTION
## Summary
- On new expansions (Midnight), tier set pieces exist in `wow_items` from BIS scraping but have no Wowhead tooltip yet — so Pass 1's `/item-set=/` detection found nothing on prod, leaving Luminous Bloom items with zero sources
- Adds fallback to Pass 1: items in tier/catalyst slots with `armor_type IS NOT NULL` + `name LIKE '% of %'` (leather/mail naming convention) + no existing sources + not crafted are treated as catalyst tier pieces and receive mirrored raid boss sources
- Cloth/plate tier pieces use different names but have Wowhead pages — caught by PRIMARY
- Zero false positives verified on dev (no non-tier items match the tightened criteria)

## Test plan
- [ ] Run Sync Loot Tables on prod — Luminous Bloom items should now get sources
- [ ] Leather druid back slot should show catalyst tier piece in gear plan drawer

🤖 Generated with [Claude Code](https://claude.com/claude-code)