### PR TITLE
fix: catalyst tier display — anchor, fallback, and source fixes

### DIFF
--- a/reference/gear-plan-2-delves-worldboss.md
+++ b/reference/gear-plan-2-delves-worldboss.md
@@ -1,0 +1,150 @@
+# Gear Plan Phase — Delves + World Boss Loot Tables
+
+> Status: Scoped, not started
+> Depends on: fix/catalyst-display merged (PR #31)
+
+---
+
+## Overview
+
+Add two new loot categories to the gear plan slot drawer:
+- **Delves** — below Crafted
+- **World Bosses** — below Delves
+
+Each requires: schema changes, sync support, and display changes.
+
+---
+
+## Schema Changes (single migration)
+
+```sql
+-- patt.raid_seasons
+ALTER TABLE patt.raid_seasons
+  ADD COLUMN current_delve_ids   INTEGER[] NOT NULL DEFAULT '{}',
+  ADD COLUMN world_boss_instance_ids INTEGER[] NOT NULL DEFAULT '{}';
+```
+
+Seed the active Midnight season:
+- `world_boss_instance_ids = {1312}` — already partially synced, instance_name='Midnight'/'World Boss'
+- `current_delve_ids` = populated once Blizzard instance IDs are found (see below)
+
+---
+
+## Delve Instance IDs
+
+The 11 Midnight delves (Blizzard instance IDs unknown — need to look up via Blizzard API Explorer
+or run `sync_item_sources` with delve detection and capture the IDs):
+
+| Delve Name |
+|---|
+| Parhelion Plaza |
+| Torment's Rise |
+| The Grudge Pit |
+| Collegiate Calamity |
+| The Darkway |
+| The Gulf of Memory |
+| The Shadow Enclave |
+| Sunkiller Sanctum |
+| Shadowguard Point |
+| Twilight Crypts |
+| Atal'Aman |
+
+**How to find IDs:** Use `/admin/blizzard-api` on prod — hit
+`GET /data/wow/journal-expansion/index` with `namespace=static-us` to find Midnight expansion ID,
+then `GET /data/wow/journal-expansion/{id}` to get the instance list. Delves appear as a separate
+category from raids and dungeons. Note all instance IDs for the 11 delves above.
+
+**Alternative:** Delves may appear in `item_sources` after the next full Sync Loot Tables run once
+the detection logic is added (see Sync Changes below). Query the DB after sync to capture IDs.
+
+---
+
+## Sync Changes (`item_source_sync.py`)
+
+### Delves
+
+Delves are in the Blizzard journal as a separate instance type. Current code only walks
+`exp_data["dungeons"]` and `exp_data["raids"]`. Need to also walk `exp_data["dungeons"]` where
+instance name matches a known delve name, OR check for a dedicated `exp_data["delves"]` key if
+Blizzard added one.
+
+**New `instance_type` value:** `'delve'`
+
+Detection logic: in `sync_item_sources`, check if the journal expansion data returns a `delves`
+key. If not, identify delves by matching instance names against `current_delve_ids` from the
+active season, or by a hardcoded name set for the expansion.
+
+### World Bosses
+
+Already working — `instance_type='world_boss'` is assigned when instance name == expansion name.
+Instance 1312 syncs correctly. No sync code changes needed.
+
+---
+
+## Admin UI Changes
+
+### Replace multi-select controls with `<select multiple>`
+
+The current tag-input-style controls for `current_raid_ids`, `current_instance_ids` are hard to use.
+Replace all three (raids, M+ dungeons, and new delves/world bosses) with simple HTML `<select multiple>`:
+
+- **Raids** — populated from `known_raids` (CharacterRaidProgress distinct raid_name/raid_id)
+- **M+ Dungeons** — populated from `item_sources WHERE instance_type='dungeon'`
+- **Delves** — populated from `item_sources WHERE instance_type='delve'`
+- **World Boss Zones** — populated from `item_sources WHERE instance_type='world_boss'`
+
+Each `<select multiple>` renders instance names, submits IDs. Selected items are highlighted.
+
+### Seeding the current season
+
+Once migration runs, update the active Midnight season via the admin UI:
+- `world_boss_instance_ids` → select "Midnight" / "World Boss" (ID 1312)
+- `current_delve_ids` → select all 11 Midnight delves (once IDs are known)
+
+---
+
+## Gear Plan Display (`gear_plan_service.py` + frontend)
+
+### `get_available_items()` — add two new source groups
+
+Current groups: `raid`, `dungeon`, `crafted`, `tier`
+New groups to add: `delve`, `world_boss`
+
+**Delves query:** Same structure as dungeon query — filter `item_sources.instance_type='delve'`
+AND `item_sources.blizzard_instance_id = ANY(current_delve_ids)`. Apply armor type + weapon stat
+filters same as dungeons.
+
+**World boss query:** Filter `item_sources.instance_type='world_boss'`
+AND `item_sources.blizzard_instance_id = ANY(world_boss_instance_ids)`. World bosses drop 8 items
+each, no tier tokens. Same filters as raid drops minus quality_tracks logic.
+
+### API response (`available-items` endpoint)
+
+Add `delve` and `world_boss` groups to the response JSON. Frontend slot drawer renders them
+below the existing Crafted section.
+
+### Frontend slot drawer
+
+Current order: Raid → Dungeon → Crafted → (Tier — separate section)
+New order: Raid → Dungeon → Crafted → Delves → World Bosses → (Tier)
+
+---
+
+## Prey / Rare Creature Drops (FUTURE — not this phase)
+
+The "Prey" items (e.g. item 251782 "Withered Saptor's Paw") may be from hunting/tracking
+rare creatures in the open world. These are NOT in the Blizzard journal. Approach TBD once
+we know whether Wowhead wraps Prey and Delves together under the same journal instance.
+
+**Trigger to revisit:** Before Season 2, or when a Prey drop becomes a hot BIS item.
+
+---
+
+## Open Questions
+
+1. Does the Blizzard journal expansion data return a `delves` key, or are delves listed
+   under `dungeons`? Check via `/admin/blizzard-api` on prod.
+2. Do Prey items share the same Blizzard journal instance as some Delves? If yes,
+   they may be captured automatically.
+3. What ilvl do Delve items cap at? (Tier 11 Delves base ilvl seems low — confirm
+   max ilvl with upgrade ranks for the `quality_ilvl_map`.)

--- a/src/guild_portal/services/gear_plan_service.py
+++ b/src/guild_portal/services/gear_plan_service.py
@@ -1747,31 +1747,34 @@ async def get_available_items(
                  WHERE wi.slot_type = ANY(ARRAY['head','shoulder','chest','hands','legs'])
                    AND wi.name LIKE '% of %'
                    AND (
+                       -- PRIMARY: Wowhead has indexed the item set link.  Any raid
+                       -- source qualifies — not gated on current_raid_ids so the
+                       -- anchor works even if the raid season config is incomplete.
                        (    wi.wowhead_tooltip_html LIKE $1
                         AND wi.wowhead_tooltip_html LIKE '%/item-set=%'
                         AND EXISTS (
                                 SELECT 1 FROM guild_identity.item_sources is2
                                  WHERE is2.item_id = wi.id
-                                   AND is2.instance_name IN (
-                                       SELECT DISTINCT is3.instance_name
-                                         FROM guild_identity.item_sources is3
-                                        WHERE is3.blizzard_instance_id = ANY($2)
-                                   )
+                                   AND is2.instance_type = 'raid'
                             )
                        )
                        OR
-                       (    wi.armor_type = $3
+                       -- FALLBACK: Wowhead hasn't indexed the set yet.  Restrict to
+                       -- items with no tooltip (not yet enriched) so enriched non-tier
+                       -- boss drops with "of" in the name are excluded.
+                       (    wi.armor_type = $2
+                        AND wi.wowhead_tooltip_html IS NULL
                         AND EXISTS (
                                 SELECT 1 FROM guild_identity.bis_list_entries ble
                                   JOIN guild_identity.specializations sp ON sp.id = ble.spec_id
                                   JOIN guild_identity.classes cl ON cl.id = sp.class_id
-                                 WHERE ble.item_id = wi.id AND cl.name = $4
+                                 WHERE ble.item_id = wi.id AND cl.name = $3
                             )
                        )
                    )
                  LIMIT 1
                 """,
-                f"%{class_name}%", raid_ids, t_armor or "leather", class_name,
+                f"%{class_name}%", t_armor or "leather", class_name,
             )
             set_suffix: Optional[str] = None
             if anchor_row:

--- a/src/guild_portal/services/gear_plan_service.py
+++ b/src/guild_portal/services/gear_plan_service.py
@@ -1761,10 +1761,6 @@ async def get_available_items(
                        )
                        OR
                        (    wi.armor_type = $3
-                        AND NOT EXISTS (
-                                SELECT 1 FROM guild_identity.item_sources s
-                                 WHERE s.item_id = wi.id
-                            )
                         AND EXISTS (
                                 SELECT 1 FROM guild_identity.bis_list_entries ble
                                   JOIN guild_identity.specializations sp ON sp.id = ble.spec_id
@@ -1826,14 +1822,12 @@ async def get_available_items(
                                 )
                            )
                            OR
-                           -- FALLBACK: items without a Wowhead tooltip yet (e.g. before
-                           --   Enrich Items has run).  Restricted to items matching the
-                           --   tier set name suffix so non-tier BIS items are excluded.
+                           -- FALLBACK: items not yet in Wowhead item-set (e.g. new
+                           --   expansion tier before Wowhead indexes the set).  Armor
+                           --   type + BIS entry + set suffix prevents non-tier items
+                           --   from appearing.  NOT gated on sources — items may have
+                           --   sources already (sources added on a prior sync).
                            (    {fallback_armor_sql.lstrip("AND ") if fallback_armor_sql else "TRUE"}
-                            AND NOT EXISTS (
-                                    SELECT 1 FROM guild_identity.item_sources s
-                                     WHERE s.item_id = wi.id
-                                )
                             AND EXISTS (
                                     SELECT 1 FROM guild_identity.bis_list_entries ble
                                       JOIN guild_identity.specializations sp ON sp.id = ble.spec_id
@@ -1850,25 +1844,19 @@ async def get_available_items(
                 )
 
             else:
-                # Catalyst slot — use the suffix we already derived above.
+                # Catalyst slot — suffix is class-discriminated (each armor class has a
+                # unique tier set name), so suffix + slot is enough.  No class filter
+                # needed — cloaks have armor_type='cloth' regardless of wearer class,
+                # and catalyst items may not have BIS entries or enriched tooltips.
                 if set_suffix:
-                    params = [slot_type, f"%{class_name}%", f"%{set_suffix}", class_name] + excl_params
+                    params = [slot_type, f"%{set_suffix}"] + excl_params
                     excl_sql = f"AND wi.id != ALL(${len(params)}::int[])" if excl_params else ""
                     tier_rows = await conn.fetch(
                         f"""
                         SELECT DISTINCT wi.blizzard_item_id, wi.name, wi.icon_url
                           FROM guild_identity.wow_items wi
                          WHERE wi.slot_type = $1
-                           AND wi.name LIKE $3
-                           AND (
-                               wi.wowhead_tooltip_html LIKE $2
-                               OR EXISTS (
-                                   SELECT 1 FROM guild_identity.bis_list_entries ble
-                                     JOIN guild_identity.specializations sp ON sp.id = ble.spec_id
-                                     JOIN guild_identity.classes cl ON cl.id = sp.class_id
-                                    WHERE ble.item_id = wi.id AND cl.name = $4
-                               )
-                           )
+                           AND wi.name LIKE $2
                            {excl_sql}
                          ORDER BY wi.name
                         """,

--- a/src/sv_common/guild_sync/item_source_sync.py
+++ b/src/sv_common/guild_sync/item_source_sync.py
@@ -822,24 +822,23 @@ async def enrich_catalyst_tier_items(
             )
             return added, errors
 
-        # Load all BIS items in catalyst slots by BIS slot (not slot_type) so that
-        # newly-stubbed items with slot_type='other' are included before Enrich Items
-        # has run to resolve their real slot.
+        # Load catalyst-slot items directly from wow_items whose name ends with a known
+        # tier suffix.  No BIS JOIN — catalyst items from the appearance crawl may not
+        # have BIS entries (e.g. leather cloaks are never recommended by BIS scrapers).
+        suffix_patterns = [f"%{s}" for s in tier_suffixes]
         all_catalyst_bis = await conn.fetch(
             """
             SELECT DISTINCT wi.id AS wow_item_id, wi.blizzard_item_id, wi.name,
-                   COALESCE(NULLIF(wi.slot_type, 'other'), ble.slot) AS eff_slot
-              FROM guild_identity.bis_list_entries ble
-              JOIN guild_identity.wow_items wi ON wi.id = ble.item_id
-             WHERE ble.slot = ANY($1::text[])
+                   wi.slot_type AS eff_slot
+              FROM guild_identity.wow_items wi
+             WHERE wi.slot_type = ANY($1::text[])
+               AND wi.name LIKE ANY($2::text[])
             """,
             list(_CATALYST_SLOTS),
+            suffix_patterns,
         )
 
-        catalyst_items = [
-            row for row in all_catalyst_bis
-            if any((row["name"] or "").endswith(suffix) for suffix in tier_suffixes)
-        ]
+        catalyst_items = list(all_catalyst_bis)
 
         if not catalyst_items:
             logger.info(


### PR DESCRIPTION
## Summary
- Anchor query: decouple from `current_raid_ids` (use `instance_type='raid'`); tighten fallback to `tooltip IS NULL` only so enriched non-tier boss drops (e.g. "Mask of Darkest Intent") can't corrupt the suffix derivation
- Main-5 display fallback: remove `NOT EXISTS(item_sources)` gate — tier items already have sources after first sync, which was causing head/shoulder to vanish
- Catalyst slot display: remove class filter entirely; tier set suffix is already class-discriminated by name, cloaks have `armor_type='cloth'` regardless of wearer
- `item_source_sync.py` Pass 2: replace `bis_list_entries` JOIN with direct `wow_items` suffix query so leather cloaks (not BIS-listed) get raid boss sources

## Test plan
- [ ] Druid gear plan back slot shows "Leafdrape of the Luminous Bloom"
- [ ] Head/shoulder/chest/hands/legs tier items still appear
- [ ] Wrist/waist/feet catalyst items appear
- [ ] Non-Druid classes still show their own tier pieces (not Druid items)
- [ ] Run Sync Loot Tables → verify catalyst items pick up sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)