### PR TITLE
Phase 1.8 — User Activity Logging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,12 +240,16 @@ Key design gotchas (read before writing any DB query):
 > Full phase-by-phase history: `reference/PHASE_HISTORY.md`
 
 ### Current Phase
-- **prod-v0.22.4 — COMPLETE** (no migration, PR #38 + patch). Phase 1.7 daily BIS pipeline fully shipped. Patch v0.22.4 disables all scheduler jobs on dev/test (`APP_ENV != 'production'` → skip all `add_job` calls, log warning, start empty scheduler). All periodic jobs prod-only; manual triggers work everywhere.
-- **prod-v0.22.3 — COMPLETE** (migration 0177, PR #38). Full Phase 1.7 daily BIS pipeline: scheduled scrape (content-hash dedup, adaptive backoff, u.gg always-daily), hourly patch probe, delta tracking, HTML email report (spec×source delta matrix), Admin UI (Daily Run History, Patch Signal badge, is_active toggle, Re-activate All, Next Check/Interval columns). `gear_plan_admin.js v1.7.1`. 1801/1807 suite-wide (6 pre-existing failures). **Post-deploy: configure SMTP in Admin → Site Config, then Run Daily Sync to validate email.**
-- **Last migration:** 0177 (`'unchanged'` added to `log.bis_scrape_log` status CHECK)
+- **Phase 1.8 — User Activity Logging** — IN PROGRESS on `feature/user-activity-logging`
+  - **Phase A COMPLETE** (commit 312ca88, migration 0178): `common.users` +`last_active_at/last_login_at/login_count`; `common.user_activity` daily rollup table; login stamping in `POST /api/v1/auth/login`
+  - **Phase B COMPLETE** (commit c43a34a): `ActivityMiddleware` in `src/guild_portal/middleware/activity.py`; registered in `app.py`; fires background upsert after each authenticated response; skips static/polling paths; 25 unit tests. 1841/1847 suite-wide (6 pre-existing).
+  - **Phase C NEXT**: Admin Users page — extend query + new columns + expand row
+  - **Phase D**: Retention pruning scheduler job
+- **prod-v0.22.4 — COMPLETE** (no migration, PR #38 + patch). Phase 1.7 daily BIS pipeline fully shipped.
+- **Last migration:** 0178 (`common.user_activity` table + `common.users` activity columns)
 - **Last prod tag:** `prod-v0.22.4`
-- **Active branch:** `main`
-- **Next planned:** TBD
+- **Active branch:** `feature/user-activity-logging`
+- **Next planned:** Phase 1.8-C (Admin Users UI)
 
 > Full phase-by-phase history: `reference/PHASE_HISTORY.md`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,8 +243,8 @@ Key design gotchas (read before writing any DB query):
 - **Phase 1.8 — User Activity Logging** — IN PROGRESS on `feature/user-activity-logging`
   - **Phase A COMPLETE** (commit 312ca88, migration 0178): `common.users` +`last_active_at/last_login_at/login_count`; `common.user_activity` daily rollup table; login stamping in `POST /api/v1/auth/login`
   - **Phase B COMPLETE** (commit c43a34a): `ActivityMiddleware` in `src/guild_portal/middleware/activity.py`; registered in `app.py`; fires background upsert after each authenticated response; skips static/polling paths; 25 unit tests. 1841/1847 suite-wide (6 pre-existing).
-  - **Phase C NEXT**: Admin Users page — extend query + new columns + expand row
-  - **Phase D**: Retention pruning scheduler job
+  - **Phase C COMPLETE** (commit 0baafeb): Admin Users page — extended query with activity data; `_rel_time()` helper; new stat pills (Active This Week, Never Logged In); new columns (Last Active, Last Login, Logins, 7d Views); expand row showing pages visited this week as tag chips; default sort by `last_active_at DESC NULLS LAST`; 31 unit tests. 1872/1878 suite-wide.
+  - **Phase D NEXT**: Retention pruning scheduler job
 - **prod-v0.22.4 — COMPLETE** (no migration, PR #38 + patch). Phase 1.7 daily BIS pipeline fully shipped.
 - **Last migration:** 0178 (`common.user_activity` table + `common.users` activity columns)
 - **Last prod tag:** `prod-v0.22.4`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,7 +241,7 @@ Key design gotchas (read before writing any DB query):
 
 ### Current Phase
 - **Phase 1.8 — User Activity Logging** — IN PROGRESS on `feature/user-activity-logging`
-  - **Phase A COMPLETE** (commit 312ca88, migration 0178): `common.users` +`last_active_at/last_login_at/login_count`; `common.user_activity` daily rollup table; login stamping in `POST /api/v1/auth/login`
+  - **Phase A COMPLETE** (commit 312ca88, migration 0178): `common.users` +`last_active_at/last_login_at/login_count`; `common.user_activity` daily rollup table; login stamping in `POST /api/v1/auth/login` **and** `POST /login` (form handler in `auth_pages.py` — fixed commit d533675; both must stamp or browser logins won't record)`
   - **Phase B COMPLETE** (commit c43a34a): `ActivityMiddleware` in `src/guild_portal/middleware/activity.py`; registered in `app.py`; fires background upsert after each authenticated response; skips static/polling paths; 25 unit tests. 1841/1847 suite-wide (6 pre-existing).
   - **Phase C COMPLETE** (commit 0baafeb): Admin Users page — extended query with activity data; `_rel_time()` helper; new stat pills (Active This Week, Never Logged In); new columns (Last Active, Last Login, Logins, 7d Views); expand row showing pages visited this week as tag chips; default sort by `last_active_at DESC NULLS LAST`; 31 unit tests. 1872/1878 suite-wide.
   - **Phase D NEXT**: Retention pruning scheduler job

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,16 +240,16 @@ Key design gotchas (read before writing any DB query):
 > Full phase-by-phase history: `reference/PHASE_HISTORY.md`
 
 ### Current Phase
-- **Phase 1.8 — User Activity Logging** — IN PROGRESS on `feature/user-activity-logging`
+- **Phase 1.8 — User Activity Logging** — **ALL PHASES COMPLETE** on `feature/user-activity-logging` — ready to merge + tag
   - **Phase A COMPLETE** (commit 312ca88, migration 0178): `common.users` +`last_active_at/last_login_at/login_count`; `common.user_activity` daily rollup table; login stamping in `POST /api/v1/auth/login` **and** `POST /login` (form handler in `auth_pages.py` — fixed commit d533675; both must stamp or browser logins won't record)`
   - **Phase B COMPLETE** (commit c43a34a): `ActivityMiddleware` in `src/guild_portal/middleware/activity.py`; registered in `app.py`; fires background upsert after each authenticated response; skips static/polling paths; 25 unit tests. 1841/1847 suite-wide (6 pre-existing).
   - **Phase C COMPLETE** (commit 0baafeb): Admin Users page — extended query with activity data; `_rel_time()` helper; new stat pills (Active This Week, Never Logged In); new columns (Last Active, Last Login, Logins, 7d Views); expand row showing pages visited this week as tag chips; default sort by `last_active_at DESC NULLS LAST`; 31 unit tests. 1872/1878 suite-wide.
-  - **Phase D NEXT**: Retention pruning scheduler job
+  - **Phase D COMPLETE** (commit 8259b6c): `run_activity_prune()` in `scheduler.py`; deletes `common.user_activity` rows older than 90 days; registered as weekly Sunday 3:30 AM UTC; 4 unit tests. 1876/1882 suite-wide.
 - **prod-v0.22.4 — COMPLETE** (no migration, PR #38 + patch). Phase 1.7 daily BIS pipeline fully shipped.
 - **Last migration:** 0178 (`common.user_activity` table + `common.users` activity columns)
 - **Last prod tag:** `prod-v0.22.4`
 - **Active branch:** `feature/user-activity-logging`
-- **Next planned:** Phase 1.8-C (Admin Users UI)
+- **Next step:** PR `feature/user-activity-logging` → `main` → tag `prod-v0.23.0` (MINOR bump — new feature)
 
 > Full phase-by-phase history: `reference/PHASE_HISTORY.md`
 

--- a/alembic/versions/0178_user_activity_logging.py
+++ b/alembic/versions/0178_user_activity_logging.py
@@ -1,0 +1,51 @@
+"""feat: user activity logging — add tracking columns + user_activity table
+
+Phase 1.8-A: adds last_active_at, last_login_at, login_count to common.users
+and creates common.user_activity for daily page-view rollups.
+
+Revision ID: 0178
+Revises: 0177
+Create Date: 2026-04-23
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0178"
+down_revision = "0177"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        ALTER TABLE common.users
+            ADD COLUMN last_active_at  TIMESTAMPTZ,
+            ADD COLUMN last_login_at   TIMESTAMPTZ,
+            ADD COLUMN login_count     INTEGER NOT NULL DEFAULT 0
+    """)
+
+    op.execute("""
+        CREATE TABLE common.user_activity (
+            id              SERIAL PRIMARY KEY,
+            user_id         INTEGER NOT NULL REFERENCES common.users(id) ON DELETE CASCADE,
+            activity_date   DATE NOT NULL DEFAULT CURRENT_DATE,
+            page_views      INTEGER NOT NULL DEFAULT 0,
+            pages_visited   TEXT[] NOT NULL DEFAULT '{}',
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            UNIQUE (user_id, activity_date)
+        )
+    """)
+
+    op.execute("CREATE INDEX ix_user_activity_user_id ON common.user_activity (user_id)")
+    op.execute("CREATE INDEX ix_user_activity_date    ON common.user_activity (activity_date DESC)")
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS common.user_activity")
+    op.execute("""
+        ALTER TABLE common.users
+            DROP COLUMN IF EXISTS last_active_at,
+            DROP COLUMN IF EXISTS last_login_at,
+            DROP COLUMN IF EXISTS login_count
+    """)

--- a/reference/gear-plan-1.8-user-logging.md
+++ b/reference/gear-plan-1.8-user-logging.md
@@ -1,0 +1,301 @@
+# Phase 1.8 — User Activity Logging
+
+> **Goal:** Track basic web activity per user (page views, last seen, login count) and surface it on the Admin → Users page. Data persists in PostgreSQL so it survives deployments.
+
+---
+
+## What We're Tracking
+
+Keep it simple and low-noise. We're not building an analytics platform — we want to answer "has this person actually used the site lately?" from the admin users table.
+
+**Per user, we want to know:**
+- Last time they visited any page (last active)
+- Last time they logged in
+- Total login count
+- Which pages they visit (lightweight summary, not a full audit trail)
+- First-party only — no external tracking, no JS beacon
+
+**What we are NOT tracking:**
+- API polling requests (the status-check endpoints that fire every few seconds)
+- Static asset requests
+- Bot/scanner traffic
+- Request bodies or form data
+
+---
+
+## Architecture Decision
+
+**Store in DB, write async, no request blocking.**
+
+Options considered:
+1. **In-memory counter + periodic flush** — data loss on restart, complex
+2. **Write every request synchronously** — adds DB latency to every page load
+3. **Write every request via background task** — chosen approach: FastAPI's `BackgroundTasks` fires after response is sent, so zero user-facing latency, and data lands in PostgreSQL (survives deployments, restarts, redeployments)
+
+The write is a simple upsert on `common.user_activity` keyed on `(user_id, date)` — one row per user per day. A separate `common.users` column (`last_active_at`) gets updated on every meaningful request.
+
+---
+
+## Schema (Migration 0178)
+
+### New columns on `common.users`
+
+```sql
+ALTER TABLE common.users
+    ADD COLUMN last_active_at   TIMESTAMPTZ,
+    ADD COLUMN last_login_at    TIMESTAMPTZ,
+    ADD COLUMN login_count      INTEGER NOT NULL DEFAULT 0;
+```
+
+`last_active_at` — updated on every non-API-poll page load (background task).  
+`last_login_at` — set on successful `POST /login`.  
+`login_count` — incremented on each successful login.
+
+### New table `common.user_activity`
+
+One row per user per UTC date — a daily rollup. Keeps the write path cheap (upsert increment) and the history queryable without a huge row count.
+
+```sql
+CREATE TABLE common.user_activity (
+    id              SERIAL PRIMARY KEY,
+    user_id         INTEGER NOT NULL REFERENCES common.users(id) ON DELETE CASCADE,
+    activity_date   DATE NOT NULL DEFAULT CURRENT_DATE,
+    page_views      INTEGER NOT NULL DEFAULT 0,
+    pages_visited   TEXT[] NOT NULL DEFAULT '{}',   -- deduped list of paths visited that day
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (user_id, activity_date)
+);
+
+CREATE INDEX ix_user_activity_user_id     ON common.user_activity (user_id);
+CREATE INDEX ix_user_activity_date        ON common.user_activity (activity_date DESC);
+```
+
+`pages_visited` stores the distinct page paths visited that day as a deduplicated TEXT array (e.g. `{"/my-characters", "/roster", "/admin/raid-tools"}`). Array append with dedup keeps it simple — no JSON needed.
+
+**Retention:** rows older than 90 days are pruned by a weekly scheduler job. At ~30 active users that's ~2,700 rows max — trivial.
+
+---
+
+## Implementation Phases
+
+### Phase A — Schema + Login tracking (migration 0178)
+
+**Files touched:**
+- `alembic/versions/0178_user_activity_logging.py` — migration
+- `src/sv_common/auth/` — update login route to stamp `last_login_at` + increment `login_count`
+
+**Login stamping** happens in `POST /api/v1/auth/login` (in `src/guild_portal/api/auth_routes.py`). After verifying password and before returning the JWT:
+
+```python
+await conn.execute("""
+    UPDATE common.users
+    SET last_login_at = NOW(),
+        login_count = login_count + 1,
+        updated_at = NOW()
+    WHERE id = $1
+""", user_id)
+```
+
+No background task needed — this is already in the login critical path.
+
+---
+
+### Phase B — Page view middleware ✅ COMPLETE (commit c43a34a, branch feature/user-activity-logging)
+
+**Files touched:**
+- `src/guild_portal/middleware/activity.py` — new file, ~60 lines
+- `src/guild_portal/app.py` — register middleware
+
+A Starlette middleware intercepts every response **after** it's been sent to the client. It:
+1. Skips if no `patt_token` cookie (unauthenticated request)
+2. Skips for paths matching an ignore list (static assets, API polling, health)
+3. Decodes the JWT to get `user_id` (already validated by the route — we just need the ID, no DB round-trip)
+4. Fires a `BackgroundTask` to write the upsert
+
+**Paths to ignore** (defined as a prefix/regex set in the middleware):
+```
+/static/
+/favicon.ico
+/health
+/api/v1/admin/bis/enrich-classify-status
+/api/v1/admin/bis/landing-status
+/api/v1/admin/bis/scrape-log
+/api/v1/me/gear-plan/*/available-items   ← repeated slot polling
+```
+
+Member-facing API routes (e.g. `GET /api/v1/me/gear-plan/{id}`) and admin API reads (e.g. `GET /api/v1/admin/bis/matrix`) are counted — these represent genuine user interactions, not just page loads.
+
+**Background upsert** (runs after response is flushed):
+
+```python
+async def _record_activity(pool, user_id: int, path: str):
+    async with pool.acquire() as conn:
+        today = date.today()
+        await conn.execute("""
+            INSERT INTO common.user_activity (user_id, activity_date, page_views, pages_visited)
+            VALUES ($1, $2, 1, ARRAY[$3]::text[])
+            ON CONFLICT (user_id, activity_date) DO UPDATE
+            SET page_views    = user_activity.page_views + 1,
+                pages_visited = CASE
+                    WHEN $3 = ANY(user_activity.pages_visited)
+                    THEN user_activity.pages_visited
+                    ELSE user_activity.pages_visited || ARRAY[$3]::text[]
+                END,
+                updated_at = NOW()
+        """, user_id, today, path)
+
+        await conn.execute("""
+            UPDATE common.users
+            SET last_active_at = NOW(), updated_at = NOW()
+            WHERE id = $1 AND (last_active_at IS NULL OR last_active_at < NOW() - INTERVAL '5 minutes')
+        """, user_id)
+```
+
+The `last_active_at` update includes a 5-minute gate — no point hammering the users row on every click.
+
+**Middleware skeleton:**
+
+```python
+class ActivityMiddleware(BaseHTTPMiddleware):
+    IGNORE_PREFIXES = ("/static/", "/favicon", "/health")
+    IGNORE_SUFFIXES = ("-status", "-log")   # polling endpoints
+
+    async def dispatch(self, request: Request, call_next):
+        response = await call_next(request)
+        token = request.cookies.get("patt_token")
+        if token and not self._should_skip(request.url.path):
+            try:
+                payload = decode_access_token(token)
+                user_id = payload.get("user_id")
+                if user_id:
+                    background = BackgroundTask(
+                        _record_activity, request.app.state.pool, user_id, request.url.path
+                    )
+                    response.background = background
+            except Exception:
+                pass   # expired/invalid token — silently skip
+        return response
+```
+
+If the response already has a background task (rare), we chain them.
+
+---
+
+### Phase C — Admin Users page UI
+
+**Files touched:**
+- `src/guild_portal/pages/admin_pages.py` — extend the `/admin/users` query
+- `src/guild_portal/templates/admin/users.html` — new columns + activity panel
+
+**Extended query** — add activity data to the existing users JOIN:
+
+```sql
+SELECT
+    u.id,
+    u.email,
+    u.is_active,
+    u.created_at,
+    u.last_login_at,
+    u.last_active_at,
+    u.login_count,
+    p.id           AS player_id,
+    p.display_name,
+    ...existing columns...,
+    -- last 7 days page view total
+    COALESCE(SUM(ua.page_views) FILTER (
+        WHERE ua.activity_date >= CURRENT_DATE - 6
+    ), 0) AS views_7d,
+    -- last active date
+    MAX(ua.activity_date) AS last_activity_date,
+    -- all-time page views
+    COALESCE(SUM(ua.page_views), 0) AS views_total
+FROM common.users u
+LEFT JOIN guild_identity.players p ON p.website_user_id = u.id
+LEFT JOIN common.guild_ranks gr ON gr.id = p.guild_rank_id
+LEFT JOIN guild_identity.battlenet_accounts ba ON ba.player_id = p.id
+LEFT JOIN common.user_activity ua ON ua.user_id = u.id
+GROUP BY u.id, p.id, gr.id, ba.id
+ORDER BY u.last_active_at DESC NULLS LAST
+```
+
+Sorting by `last_active_at DESC` by default — most recently active users at the top, which is far more useful than creation order.
+
+**New columns in the table:**
+
+| Column | Value |
+|--------|-------|
+| Last Active | `last_active_at` relative ("2h ago", "3d ago", "never") |
+| Last Login | `last_login_at` date |
+| Logins | `login_count` |
+| 7d Views | `views_7d` page views in the rolling 7 days |
+
+**Activity detail row** — clicking a row (or a ▶ expand button) expands an inline sub-row showing the `pages_visited` array for the last 7 days as a compact tag list. No modal needed — the inline expand pattern is already used elsewhere in the admin templates.
+
+**Stats pills** — the existing stat pills row gets two additions:
+- "Active this week" — count of users with `last_active_at >= 7 days ago`
+- "Never logged in" — count of users with `login_count = 0`
+
+---
+
+### Phase D — Retention pruning job
+
+**Files touched:**
+- `src/sv_common/guild_sync/scheduler.py` — add weekly prune job
+
+```python
+@scheduler.scheduled_job(CronTrigger(day_of_week="sun", hour=3))
+async def prune_old_activity():
+    async with pool.acquire() as conn:
+        deleted = await conn.execute("""
+            DELETE FROM common.user_activity
+            WHERE activity_date < CURRENT_DATE - 90
+        """)
+        logger.info(f"Pruned old user_activity rows: {deleted}")
+```
+
+Runs Sunday 3am UTC. At ~30 users, 90-day retention = ~2,700 rows max — basically nothing.
+
+---
+
+## File Summary
+
+| File | Change |
+|------|--------|
+| `alembic/versions/0178_user_activity_logging.py` | New migration — columns + table |
+| `src/guild_portal/middleware/activity.py` | New — ActivityMiddleware + _record_activity |
+| `src/guild_portal/app.py` | Register ActivityMiddleware |
+| `src/sv_common/auth/` (login route) | Stamp last_login_at + increment login_count on successful login |
+| `src/guild_portal/pages/admin_pages.py` | Extend /admin/users query with activity data |
+| `src/guild_portal/templates/admin/users.html` | New columns, expand row, updated stat pills |
+| `src/sv_common/guild_sync/scheduler.py` | Weekly prune job |
+
+---
+
+## Migration Safety
+
+- All new columns are nullable or have defaults — zero downtime, no backfill required
+- `login_count DEFAULT 0` — existing users start at 0 (accurate for "logins after this deploy")
+- `last_active_at` and `last_login_at` start NULL — displayed as "never" in the UI, which is correct
+- The `user_activity` table starts empty — that's fine, data accumulates naturally
+- Rolling back: drop the table + columns, remove middleware registration — no data dependency in other tables
+
+---
+
+## Test Coverage
+
+- Unit tests for `_record_activity()`: first visit creates row, subsequent visits increment, new day creates new row, path dedup works
+- Unit tests for middleware path filtering: static/polling paths skipped, page paths tracked, unauthenticated requests skipped, expired token silently skipped
+- Unit tests for login stamping: `last_login_at` and `login_count` updated on successful login
+- Unit test for prune job: rows older than 90 days deleted, recent rows untouched
+- Admin users query: returns `views_7d`, `views_total`, `last_active_at` correctly
+
+Estimated: ~20 new tests across 3 test files.
+
+---
+
+## Build Order
+
+**Phase A** → **Phase B** → **Phase C** → **Phase D**
+
+Each phase is independently deployable. Phase C (UI) is the only user-visible change — Phases A and B can ship silently first and accumulate data before the UI is wired up.

--- a/reference/gear-plan-1.8-user-logging.md
+++ b/reference/gear-plan-1.8-user-logging.md
@@ -182,7 +182,7 @@ If the response already has a background task (rare), we chain them.
 
 ---
 
-### Phase C — Admin Users page UI
+### Phase C — Admin Users page UI ✅ COMPLETE (commit 0baafeb, branch feature/user-activity-logging)
 
 **Files touched:**
 - `src/guild_portal/pages/admin_pages.py` — extend the `/admin/users` query

--- a/reference/gear-plan-1.8-user-logging.md
+++ b/reference/gear-plan-1.8-user-logging.md
@@ -238,7 +238,7 @@ Sorting by `last_active_at DESC` by default — most recently active users at th
 
 ---
 
-### Phase D — Retention pruning job
+### Phase D — Retention pruning job ✅ COMPLETE (commit 8259b6c, branch feature/user-activity-logging)
 
 **Files touched:**
 - `src/sv_common/guild_sync/scheduler.py` — add weekly prune job

--- a/src/guild_portal/api/auth_routes.py
+++ b/src/guild_portal/api/auth_routes.py
@@ -1,6 +1,7 @@
 """Authentication API — register, login, profile."""
 
 import logging
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
@@ -139,6 +140,10 @@ async def login(body: LoginBody, db: AsyncSession = Depends(get_db)):
         raise HTTPException(status_code=401, detail="No player account linked.")
 
     rank_level = player.guild_rank.level if player.guild_rank else 1
+
+    user.last_login_at = datetime.now(timezone.utc)
+    user.login_count = (user.login_count or 0) + 1
+    await db.flush()
 
     token = create_access_token(
         user_id=user.id,

--- a/src/guild_portal/app.py
+++ b/src/guild_portal/app.py
@@ -308,6 +308,10 @@ def create_app() -> FastAPI:
     # Security headers on every response
     app.add_middleware(SecurityHeadersMiddleware)
 
+    # Activity tracking — records page views per authenticated user (post-response, no latency)
+    from guild_portal.middleware.activity import ActivityMiddleware
+    app.add_middleware(ActivityMiddleware)
+
     # ---------------------------------------------------------------------------
     # Exception handlers
     # ---------------------------------------------------------------------------

--- a/src/guild_portal/middleware/activity.py
+++ b/src/guild_portal/middleware/activity.py
@@ -1,0 +1,114 @@
+"""ActivityMiddleware — records page views per authenticated user after each response."""
+
+import logging
+import re
+from datetime import date
+from typing import Callable
+
+import asyncpg
+from starlette.background import BackgroundTask
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+from sv_common.auth.jwt import decode_access_token
+
+logger = logging.getLogger(__name__)
+
+# Paths where activity should NOT be recorded
+_IGNORE_PREFIXES = (
+    "/static/",
+    "/favicon",
+    "/health",
+)
+
+# Endpoint path suffixes that indicate polling — skip these
+_IGNORE_SUFFIXES = (
+    "-status",
+    "-log",
+)
+
+# Regex for slot-level polling: /api/v1/me/gear-plan/<id>/available-items
+_AVAILABLE_ITEMS_RE = re.compile(r"^/api/v1/me/gear-plan/\d+/available-items")
+
+
+def _should_skip(path: str) -> bool:
+    if any(path.startswith(p) for p in _IGNORE_PREFIXES):
+        return True
+    if any(path.endswith(s) for s in _IGNORE_SUFFIXES):
+        return True
+    if _AVAILABLE_ITEMS_RE.match(path):
+        return True
+    return False
+
+
+async def _record_activity(pool: asyncpg.Pool, user_id: int, path: str) -> None:
+    try:
+        async with pool.acquire() as conn:
+            today = date.today()
+            await conn.execute(
+                """
+                INSERT INTO common.user_activity (user_id, activity_date, page_views, pages_visited)
+                VALUES ($1, $2, 1, ARRAY[$3]::text[])
+                ON CONFLICT (user_id, activity_date) DO UPDATE
+                SET page_views    = user_activity.page_views + 1,
+                    pages_visited = CASE
+                        WHEN $3 = ANY(user_activity.pages_visited)
+                        THEN user_activity.pages_visited
+                        ELSE user_activity.pages_visited || ARRAY[$3]::text[]
+                    END,
+                    updated_at = NOW()
+                """,
+                user_id,
+                today,
+                path,
+            )
+            await conn.execute(
+                """
+                UPDATE common.users
+                SET last_active_at = NOW(), updated_at = NOW()
+                WHERE id = $1
+                  AND (last_active_at IS NULL OR last_active_at < NOW() - INTERVAL '5 minutes')
+                """,
+                user_id,
+            )
+    except Exception:
+        logger.debug("Activity record failed for user %s path %s", user_id, path, exc_info=True)
+
+
+class ActivityMiddleware(BaseHTTPMiddleware):
+    """Records page-view activity for authenticated users after the response is flushed."""
+
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        response = await call_next(request)
+
+        token = request.cookies.get("patt_token")
+        if not token or _should_skip(request.url.path):
+            return response
+
+        pool: asyncpg.Pool | None = getattr(request.app.state, "guild_sync_pool", None)
+        if pool is None:
+            return response
+
+        try:
+            payload = decode_access_token(token)
+            user_id = payload.get("user_id")
+            if user_id:
+                task = BackgroundTask(_record_activity, pool, user_id, request.url.path)
+                if response.background is None:
+                    response.background = task
+                else:
+                    # Chain with any existing background task
+                    existing = response.background
+                    response.background = BackgroundTask(
+                        _chain_tasks, existing, task
+                    )
+        except Exception:
+            pass  # expired/invalid token — silently skip
+
+        return response
+
+
+async def _chain_tasks(first: BackgroundTask, second: BackgroundTask) -> None:
+    await first()
+    await second()

--- a/src/guild_portal/pages/admin_pages.py
+++ b/src/guild_portal/pages/admin_pages.py
@@ -2447,6 +2447,28 @@ async def admin_audit_resolve(
 # ---------------------------------------------------------------------------
 
 
+def _rel_time(dt: datetime | None) -> str:
+    """Return a human-readable relative time string for a UTC datetime."""
+    if dt is None:
+        return "never"
+    now = datetime.now(timezone.utc)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    secs = int((now - dt).total_seconds())
+    if secs < 60:
+        return "just now"
+    if secs < 3600:
+        return f"{secs // 60}m ago"
+    if secs < 86400:
+        return f"{secs // 3600}h ago"
+    days = secs // 86400
+    if days < 30:
+        return f"{days}d ago"
+    if days < 365:
+        return f"{days // 30}mo ago"
+    return f"{days // 365}y ago"
+
+
 @router.get("/users", response_class=HTMLResponse)
 async def admin_users(
     request: Request,
@@ -2459,17 +2481,39 @@ async def admin_users(
     rows = await db.execute(
         text("""
             SELECT u.id, u.email, u.is_active, u.created_at,
+                   u.last_login_at, u.last_active_at, u.login_count,
                    p.id                    AS player_id,
                    p.display_name,
                    gr.name                 AS rank_name,
                    ba.battletag            AS battletag,
                    ba.last_character_sync  AS last_bnet_sync,
-                   ba.token_expires_at     AS bnet_token_expires_at
+                   ba.token_expires_at     AS bnet_token_expires_at,
+                   COALESCE((
+                       SELECT SUM(ua.page_views)
+                       FROM common.user_activity ua
+                       WHERE ua.user_id = u.id AND ua.activity_date >= CURRENT_DATE - 6
+                   ), 0)::integer AS views_7d,
+                   COALESCE((
+                       SELECT SUM(ua.page_views)
+                       FROM common.user_activity ua
+                       WHERE ua.user_id = u.id
+                   ), 0)::integer AS views_total,
+                   (
+                       SELECT MAX(ua.activity_date)
+                       FROM common.user_activity ua
+                       WHERE ua.user_id = u.id
+                   ) AS last_activity_date,
+                   (
+                       SELECT array_agg(DISTINCT path ORDER BY path)
+                       FROM common.user_activity ua,
+                            unnest(ua.pages_visited) AS path
+                       WHERE ua.user_id = u.id AND ua.activity_date >= CURRENT_DATE - 6
+                   ) AS pages_7d
             FROM common.users u
             LEFT JOIN guild_identity.players p ON p.website_user_id = u.id
             LEFT JOIN common.guild_ranks gr ON gr.id = p.guild_rank_id
             LEFT JOIN guild_identity.battlenet_accounts ba ON ba.player_id = p.id
-            ORDER BY u.created_at DESC
+            ORDER BY u.last_active_at DESC NULLS LAST
         """)
     )
     now = datetime.now(timezone.utc)
@@ -2480,10 +2524,22 @@ async def admin_users(
         u["bnet_token_expired"] = bool(
             expires_at and expires_at <= now
         )
+        u["last_active_rel"] = _rel_time(u.get("last_active_at"))
+        u["last_login_rel"] = _rel_time(u.get("last_login_at"))
+        u["pages_7d"] = u.get("pages_7d") or []
         users.append(u)
+
+    active_week = sum(
+        1 for u in users
+        if u.get("last_active_at") is not None
+        and (now - (u["last_active_at"].replace(tzinfo=timezone.utc) if u["last_active_at"].tzinfo is None else u["last_active_at"])).days < 7
+    )
+    never_logged_in = sum(1 for u in users if not u.get("login_count"))
 
     ctx = await _base_ctx(request, player, db)
     ctx["users"] = users
+    ctx["active_week"] = active_week
+    ctx["never_logged_in"] = never_logged_in
     return templates.TemplateResponse("admin/users.html", ctx)
 
 

--- a/src/guild_portal/pages/auth_pages.py
+++ b/src/guild_portal/pages/auth_pages.py
@@ -114,6 +114,11 @@ async def login_post(
     if player is None:
         return render_error("No player account linked to this login.")
 
+    from datetime import datetime, timezone
+    user.last_login_at = datetime.now(timezone.utc)
+    user.login_count = (user.login_count or 0) + 1
+    await db.flush()
+
     token = create_access_token(
         user_id=user.id,
         member_id=player.id,

--- a/src/guild_portal/templates/admin/users.html
+++ b/src/guild_portal/templates/admin/users.html
@@ -274,6 +274,68 @@
 }
 .ua-modal__actions .btn { font-size: 0.875rem; }
 
+/* ------------------------------------------------------------------ activity stat pills */
+.ua-stat--week .ua-stat__num  { color: #60a5fa; }
+.ua-stat--never .ua-stat__num { color: var(--color-text-muted); }
+
+/* ------------------------------------------------------------------ activity columns */
+.ua-td-activity {
+    font-size: 0.82rem;
+    white-space: nowrap;
+    color: var(--color-text-muted);
+}
+.ua-td-activity--recent { color: var(--color-text); }
+.ua-td-mono {
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    color: var(--color-text-muted);
+}
+.ua-td-mono--nonzero { color: var(--color-text); }
+
+/* ------------------------------------------------------------------ expand toggle */
+.ua-expand-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--color-text-muted);
+    font-size: 0.65rem;
+    padding: 0.25rem;
+    line-height: 1;
+    transition: color 0.15s, transform 0.15s;
+}
+.ua-expand-btn:hover { color: var(--color-accent); }
+.ua-expand-btn.is-open { transform: rotate(90deg); color: var(--color-accent); }
+
+/* ------------------------------------------------------------------ expand detail row */
+.ua-expand-row td {
+    padding: 0.6rem 1rem 0.8rem 2.5rem;
+    background: var(--color-bg-card);
+    border-bottom: 1px solid var(--color-border);
+}
+.ua-expand-content {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+}
+.ua-expand-label {
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    color: var(--color-text-muted);
+    margin-right: 0.25rem;
+    white-space: nowrap;
+}
+.ua-page-tag {
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    background: rgba(212, 168, 75, 0.08);
+    border: 1px solid rgba(212, 168, 75, 0.2);
+    color: var(--color-accent);
+    border-radius: var(--radius-sm);
+    padding: 0.15rem 0.5rem;
+}
+
 /* ------------------------------------------------------------------ bnet cell */
 .ua-bnet-tag {
     font-family: var(--font-mono);
@@ -353,6 +415,16 @@
         <div class="ua-stat__num">{{ active }}</div>
         <div class="ua-stat__label">Active</div>
     </div>
+    <div class="ua-stat ua-stat--week">
+        <div class="ua-stat__num">{{ active_week }}</div>
+        <div class="ua-stat__label">Active This Week</div>
+    </div>
+    {% if never_logged_in %}
+    <div class="ua-stat ua-stat--never">
+        <div class="ua-stat__num">{{ never_logged_in }}</div>
+        <div class="ua-stat__label">Never Logged In</div>
+    </div>
+    {% endif %}
     {% if disabled %}
     <div class="ua-stat ua-stat--disabled">
         <div class="ua-stat__num">{{ disabled }}</div>
@@ -372,11 +444,16 @@
     <table class="ua-table">
         <thead>
             <tr>
+                <th style="width:1.5rem"></th>
                 <th>Email</th>
                 <th>Player</th>
                 <th>Rank</th>
                 <th>Battle.net</th>
                 <th>Status</th>
+                <th>Last Active</th>
+                <th>Last Login</th>
+                <th>Logins</th>
+                <th>7d Views</th>
                 <th>Joined</th>
                 <th></th>
             </tr>
@@ -384,6 +461,15 @@
         <tbody>
         {% for u in users %}
         <tr id="user-row-{{ u.id }}">
+            <td style="padding:0.75rem 0.25rem 0.75rem 0.75rem">
+                {% if u.pages_7d %}
+                <button class="ua-expand-btn"
+                        id="expand-btn-{{ u.id }}"
+                        onclick="toggleExpand({{ u.id }})"
+                        aria-expanded="false"
+                        title="Show pages visited this week">&#9658;</button>
+                {% endif %}
+            </td>
             <td class="ua-td-email">{{ u.email or '—' }}</td>
             <td class="ua-td-player">
                 {% if u.player_id %}
@@ -413,6 +499,20 @@
                     <span class="ua-badge__dot"></span>
                     {% if u.is_active %}Active{% else %}Disabled{% endif %}
                 </span>
+            </td>
+            <td class="ua-td-activity{% if u.last_active_rel not in ('never',) %} ua-td-activity--recent{% endif %}"
+                title="{{ u.last_active_at.strftime('%Y-%m-%d %H:%M UTC') if u.last_active_at else '' }}">
+                {{ u.last_active_rel }}
+            </td>
+            <td class="ua-td-activity"
+                title="{{ u.last_login_at.strftime('%Y-%m-%d %H:%M UTC') if u.last_login_at else '' }}">
+                {{ u.last_login_rel }}
+            </td>
+            <td class="ua-td-mono{% if u.login_count %} ua-td-mono--nonzero{% endif %}">
+                {{ u.login_count }}
+            </td>
+            <td class="ua-td-mono{% if u.views_7d %} ua-td-mono--nonzero{% endif %}">
+                {{ u.views_7d }}
             </td>
             <td class="ua-td-joined">
                 {{ u.created_at.strftime('%Y-%m-%d') if u.created_at else '—' }}
@@ -449,6 +549,16 @@
                         onclick="deleteUser(this)">
                     Delete
                 </button>
+            </td>
+        </tr>
+        <tr id="user-expand-{{ u.id }}" class="ua-expand-row" hidden>
+            <td colspan="12">
+                <div class="ua-expand-content">
+                    <span class="ua-expand-label">Pages this week:</span>
+                    {% for path in u.pages_7d %}
+                    <span class="ua-page-tag">{{ path }}</span>
+                    {% endfor %}
+                </div>
             </td>
         </tr>
         {% endfor %}
@@ -505,6 +615,16 @@
 
 {% block scripts %}
 <script>
+function toggleExpand(userId) {
+    const row = document.getElementById(`user-expand-${userId}`);
+    const btn = document.getElementById(`expand-btn-${userId}`);
+    if (!row || !btn) return;
+    const opening = row.hidden;
+    row.hidden = !opening;
+    btn.classList.toggle('is-open', opening);
+    btn.setAttribute('aria-expanded', opening);
+}
+
 function showToast(msg, type) {
     const t = document.getElementById('ua-toast');
     t.textContent = msg;

--- a/src/sv_common/db/models.py
+++ b/src/sv_common/db/models.py
@@ -77,6 +77,9 @@ class User(Base):
     phone: Mapped[Optional[str]] = mapped_column(String(20))
     password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    last_active_at: Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True))
+    last_login_at: Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True))
+    login_count: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
     created_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True), server_default=func.now()
     )

--- a/src/sv_common/guild_sync/scheduler.py
+++ b/src/sv_common/guild_sync/scheduler.py
@@ -272,6 +272,15 @@ class GuildSyncScheduler:
             misfire_grace_time=3600,
         )
 
+        # User activity data retention prune: weekly Sunday at 3:30 AM UTC
+        self.scheduler.add_job(
+            self.run_activity_prune,
+            CronTrigger(day_of_week="sun", hour=3, minute=30),
+            id="activity_prune",
+            name="User Activity Data Retention Prune",
+            misfire_grace_time=3600,
+        )
+
         # Archon BIS sync: weekly on Monday at 6 AM UTC
         self.scheduler.add_job(
             self.run_archon_sync,
@@ -720,6 +729,17 @@ class GuildSyncScheduler:
                     "Roleless Member Prune Failed",
                     f"The roleless member prune encountered an unexpected error:\n```{exc}```",
                 )
+
+    async def run_activity_prune(self):
+        """Prune user_activity rows older than 90 days. Runs weekly on Sunday at 3:30 AM UTC."""
+        try:
+            async with self.db_pool.acquire() as conn:
+                result = await conn.execute(
+                    "DELETE FROM common.user_activity WHERE activity_date < CURRENT_DATE - 90"
+                )
+            logger.info("Activity prune complete: %s", result)
+        except Exception as exc:
+            logger.error("Activity prune failed: %s", exc, exc_info=True)
 
     async def run_weekly_progression_sweep(self):
         """Weekly full progression sweep: snapshots + achievement sync (all characters).

--- a/src/sv_common/guild_sync/scheduler.py
+++ b/src/sv_common/guild_sync/scheduler.py
@@ -740,6 +740,22 @@ class GuildSyncScheduler:
             logger.info("Activity prune complete: %s", result)
         except Exception as exc:
             logger.error("Activity prune failed: %s", exc, exc_info=True)
+            from sv_common.errors import report_error
+            from guild_portal.services.error_routing import maybe_notify_discord
+            result = await report_error(
+                self.db_pool,
+                "activity_prune_failed",
+                "warning",
+                str(exc),
+                "scheduler",
+                details={"error": str(exc)},
+            )
+            await maybe_notify_discord(
+                self.db_pool, self.discord_bot, self.audit_channel_id,
+                "activity_prune_failed", "warning",
+                f"The user activity retention prune job failed: {exc}",
+                result["is_first_occurrence"],
+            )
 
     async def run_weekly_progression_sweep(self):
         """Weekly full progression sweep: snapshots + achievement sync (all characters).

--- a/tests/unit/test_activity_middleware.py
+++ b/tests/unit/test_activity_middleware.py
@@ -1,0 +1,279 @@
+"""Unit tests for guild_portal.middleware.activity — path filtering and record logic."""
+
+import os
+from datetime import date, datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch, call
+
+import pytest
+
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+os.environ.setdefault("JWT_SECRET_KEY", "unit-test-secret-key-for-jwt-32chars!")
+os.environ.setdefault("APP_ENV", "testing")
+
+
+# ---------------------------------------------------------------------------
+# _should_skip
+# ---------------------------------------------------------------------------
+
+
+class TestShouldSkip:
+    def _skip(self, path: str) -> bool:
+        from guild_portal.middleware.activity import _should_skip
+        return _should_skip(path)
+
+    def test_static_prefix_skipped(self):
+        assert self._skip("/static/js/main.js") is True
+
+    def test_favicon_skipped(self):
+        assert self._skip("/favicon.ico") is True
+
+    def test_health_skipped(self):
+        assert self._skip("/health") is True
+
+    def test_enrich_classify_status_skipped(self):
+        assert self._skip("/api/v1/admin/bis/enrich-classify-status") is True
+
+    def test_landing_status_skipped(self):
+        assert self._skip("/api/v1/admin/bis/landing-status") is True
+
+    def test_scrape_log_skipped(self):
+        assert self._skip("/api/v1/admin/bis/scrape-log") is True
+
+    def test_available_items_polling_skipped(self):
+        assert self._skip("/api/v1/me/gear-plan/42/available-items") is True
+
+    def test_regular_page_not_skipped(self):
+        assert self._skip("/roster") is False
+
+    def test_my_characters_not_skipped(self):
+        assert self._skip("/my-characters") is False
+
+    def test_admin_page_not_skipped(self):
+        assert self._skip("/admin/raid-tools") is False
+
+    def test_gear_plan_api_not_skipped(self):
+        assert self._skip("/api/v1/me/gear-plan/42") is False
+
+    def test_bis_matrix_api_not_skipped(self):
+        assert self._skip("/api/v1/admin/bis/matrix") is False
+
+    def test_login_api_not_skipped(self):
+        assert self._skip("/api/v1/auth/login") is False
+
+    def test_admin_users_page_not_skipped(self):
+        assert self._skip("/admin/users") is False
+
+
+# ---------------------------------------------------------------------------
+# _record_activity
+# ---------------------------------------------------------------------------
+
+
+class TestRecordActivity:
+    @pytest.mark.asyncio
+    async def test_first_visit_inserts_row(self):
+        from guild_portal.middleware.activity import _record_activity
+
+        conn = AsyncMock()
+        pool = MagicMock()
+        pool.acquire.return_value.__aenter__ = AsyncMock(return_value=conn)
+        pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await _record_activity(pool, user_id=7, path="/roster")
+
+        assert conn.execute.call_count == 2
+        first_call_sql = conn.execute.call_args_list[0][0][0]
+        assert "INSERT INTO common.user_activity" in first_call_sql
+        assert "ON CONFLICT" in first_call_sql
+
+    @pytest.mark.asyncio
+    async def test_subsequent_visit_increments(self):
+        from guild_portal.middleware.activity import _record_activity
+
+        conn = AsyncMock()
+        pool = MagicMock()
+        pool.acquire.return_value.__aenter__ = AsyncMock(return_value=conn)
+        pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        # Call twice — both should use upsert (increment handled by SQL)
+        await _record_activity(pool, user_id=7, path="/roster")
+        await _record_activity(pool, user_id=7, path="/roster")
+
+        assert conn.execute.call_count == 4  # 2 calls per visit
+
+    @pytest.mark.asyncio
+    async def test_last_active_update_included(self):
+        from guild_portal.middleware.activity import _record_activity
+
+        conn = AsyncMock()
+        pool = MagicMock()
+        pool.acquire.return_value.__aenter__ = AsyncMock(return_value=conn)
+        pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await _record_activity(pool, user_id=3, path="/my-characters")
+
+        second_call_sql = conn.execute.call_args_list[1][0][0]
+        assert "UPDATE common.users" in second_call_sql
+        assert "last_active_at" in second_call_sql
+
+    @pytest.mark.asyncio
+    async def test_db_error_silently_swallowed(self):
+        from guild_portal.middleware.activity import _record_activity
+
+        conn = AsyncMock()
+        conn.execute.side_effect = Exception("DB error")
+        pool = MagicMock()
+        pool.acquire.return_value.__aenter__ = AsyncMock(return_value=conn)
+        pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        # Should not raise
+        await _record_activity(pool, user_id=1, path="/roster")
+
+    @pytest.mark.asyncio
+    async def test_path_passed_to_insert(self):
+        from guild_portal.middleware.activity import _record_activity
+
+        conn = AsyncMock()
+        pool = MagicMock()
+        pool.acquire.return_value.__aenter__ = AsyncMock(return_value=conn)
+        pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await _record_activity(pool, user_id=5, path="/admin/gear-plan-admin")
+
+        insert_args = conn.execute.call_args_list[0][0]
+        assert "/admin/gear-plan-admin" in insert_args
+
+
+# ---------------------------------------------------------------------------
+# ActivityMiddleware.dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestActivityMiddlewareDispatch:
+    def _make_request(self, path: str, token: str | None = None) -> MagicMock:
+        request = MagicMock()
+        request.url.path = path
+        request.cookies = {"patt_token": token} if token else {}
+        pool = MagicMock()
+        request.app.state.guild_sync_pool = pool
+        return request
+
+    def _make_valid_token(self, user_id: int = 42) -> str:
+        import jwt
+        from guild_portal.config import get_settings
+        settings = get_settings()
+        payload = {
+            "user_id": user_id,
+            "member_id": 1,
+            "rank_level": 5,
+            "exp": datetime.now(timezone.utc) + timedelta(minutes=60),
+            "iat": datetime.now(timezone.utc),
+        }
+        return jwt.encode(payload, settings.jwt_secret_key, algorithm="HS256")
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_request_skips_tracking(self):
+        from guild_portal.middleware.activity import ActivityMiddleware
+
+        middleware = ActivityMiddleware(app=MagicMock())
+        request = self._make_request("/roster", token=None)
+        mock_response = MagicMock()
+        mock_response.background = None
+
+        call_next = AsyncMock(return_value=mock_response)
+        response = await middleware.dispatch(request, call_next)
+
+        assert response.background is None
+
+    @pytest.mark.asyncio
+    async def test_static_path_skips_tracking(self):
+        from guild_portal.middleware.activity import ActivityMiddleware
+
+        middleware = ActivityMiddleware(app=MagicMock())
+        token = self._make_valid_token()
+        request = self._make_request("/static/js/main.js", token=token)
+        mock_response = MagicMock()
+        mock_response.background = None
+
+        call_next = AsyncMock(return_value=mock_response)
+        response = await middleware.dispatch(request, call_next)
+
+        assert response.background is None
+
+    @pytest.mark.asyncio
+    async def test_authenticated_page_sets_background_task(self):
+        from guild_portal.middleware.activity import ActivityMiddleware
+        from starlette.background import BackgroundTask
+
+        middleware = ActivityMiddleware(app=MagicMock())
+        token = self._make_valid_token(user_id=7)
+        request = self._make_request("/roster", token=token)
+        mock_response = MagicMock()
+        mock_response.background = None
+
+        call_next = AsyncMock(return_value=mock_response)
+        response = await middleware.dispatch(request, call_next)
+
+        assert response.background is not None
+
+    @pytest.mark.asyncio
+    async def test_expired_token_skips_tracking(self):
+        from guild_portal.middleware.activity import ActivityMiddleware
+        import jwt
+        from guild_portal.config import get_settings
+
+        settings = get_settings()
+        expired_payload = {
+            "user_id": 1,
+            "member_id": 1,
+            "rank_level": 5,
+            "exp": datetime.now(timezone.utc) - timedelta(minutes=5),
+            "iat": datetime.now(timezone.utc) - timedelta(minutes=65),
+        }
+        expired_token = jwt.encode(expired_payload, settings.jwt_secret_key, algorithm="HS256")
+
+        middleware = ActivityMiddleware(app=MagicMock())
+        request = self._make_request("/roster", token=expired_token)
+        mock_response = MagicMock()
+        mock_response.background = None
+
+        call_next = AsyncMock(return_value=mock_response)
+        response = await middleware.dispatch(request, call_next)
+
+        assert response.background is None
+
+    @pytest.mark.asyncio
+    async def test_no_pool_skips_tracking(self):
+        from guild_portal.middleware.activity import ActivityMiddleware
+
+        middleware = ActivityMiddleware(app=MagicMock())
+        token = self._make_valid_token()
+        request = self._make_request("/roster", token=token)
+        request.app.state.guild_sync_pool = None
+        mock_response = MagicMock()
+        mock_response.background = None
+
+        call_next = AsyncMock(return_value=mock_response)
+        response = await middleware.dispatch(request, call_next)
+
+        assert response.background is None
+
+    @pytest.mark.asyncio
+    async def test_existing_background_task_chained(self):
+        from guild_portal.middleware.activity import ActivityMiddleware
+        from starlette.background import BackgroundTask
+
+        middleware = ActivityMiddleware(app=MagicMock())
+        token = self._make_valid_token(user_id=9)
+        request = self._make_request("/my-characters", token=token)
+
+        existing_task = BackgroundTask(lambda: None)
+        mock_response = MagicMock()
+        mock_response.background = existing_task
+
+        call_next = AsyncMock(return_value=mock_response)
+        response = await middleware.dispatch(request, call_next)
+
+        # Should have been replaced with a chaining task, not the original
+        assert response.background is not existing_task
+        assert response.background is not None

--- a/tests/unit/test_activity_prune.py
+++ b/tests/unit/test_activity_prune.py
@@ -1,0 +1,115 @@
+"""Unit tests for Phase 1.8-D — User activity retention prune job.
+
+Tests:
+1. run_activity_prune: executes DELETE with correct SQL
+2. run_activity_prune: logs completion message with result
+3. run_activity_prune: handles DB exception without propagating
+4. start() registers activity_prune job in production
+"""
+
+import os
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch, call
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_scheduler():
+    """Build a GuildSyncScheduler with all external deps mocked out."""
+    from sv_common.guild_sync.scheduler import GuildSyncScheduler
+
+    db_pool = MagicMock()
+    bot = MagicMock()
+    audit_channel_id = 99999
+
+    env_overrides = {
+        "BLIZZARD_CLIENT_ID": "test-client-id",
+        "BLIZZARD_CLIENT_SECRET": "test-client-secret",
+    }
+
+    with patch("sv_common.guild_sync.scheduler.BlizzardClient") as mock_bc_cls, \
+         patch("sv_common.guild_sync.scheduler.get_site_config", return_value={}), \
+         patch.dict(os.environ, env_overrides):
+        mock_bc_cls.return_value = MagicMock()
+        scheduler = GuildSyncScheduler(db_pool, bot, audit_channel_id)
+
+    scheduler.scheduler = MagicMock()
+    return scheduler
+
+
+# ---------------------------------------------------------------------------
+# 1–3. run_activity_prune behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestRunActivityPrune:
+    @pytest.mark.asyncio
+    async def test_executes_delete_sql(self):
+        scheduler = _make_scheduler()
+
+        mock_conn = AsyncMock()
+        mock_conn.execute = AsyncMock(return_value="DELETE 5")
+        mock_pool_ctx = MagicMock()
+        mock_pool_ctx.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_pool_ctx.__aexit__ = AsyncMock(return_value=False)
+        scheduler.db_pool.acquire = MagicMock(return_value=mock_pool_ctx)
+
+        await scheduler.run_activity_prune()
+
+        mock_conn.execute.assert_called_once()
+        sql = mock_conn.execute.call_args[0][0]
+        assert "DELETE FROM common.user_activity" in sql
+        assert "CURRENT_DATE - 90" in sql
+
+    @pytest.mark.asyncio
+    async def test_logs_completion(self, caplog):
+        import logging
+        scheduler = _make_scheduler()
+
+        mock_conn = AsyncMock()
+        mock_conn.execute = AsyncMock(return_value="DELETE 12")
+        mock_pool_ctx = MagicMock()
+        mock_pool_ctx.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_pool_ctx.__aexit__ = AsyncMock(return_value=False)
+        scheduler.db_pool.acquire = MagicMock(return_value=mock_pool_ctx)
+
+        with caplog.at_level(logging.INFO, logger="sv_common.guild_sync.scheduler"):
+            await scheduler.run_activity_prune()
+
+        assert any("Activity prune complete" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_handles_db_exception_without_propagating(self):
+        scheduler = _make_scheduler()
+
+        mock_pool_ctx = MagicMock()
+        mock_pool_ctx.__aenter__ = AsyncMock(side_effect=Exception("DB is down"))
+        mock_pool_ctx.__aexit__ = AsyncMock(return_value=False)
+        scheduler.db_pool.acquire = MagicMock(return_value=mock_pool_ctx)
+
+        # Should not raise
+        await scheduler.run_activity_prune()
+
+
+# ---------------------------------------------------------------------------
+# 4. start() registers activity_prune job
+# ---------------------------------------------------------------------------
+
+
+class TestSchedulerRegistersActivityPruneJob:
+    @pytest.mark.asyncio
+    async def test_start_registers_activity_prune_job(self):
+        scheduler = _make_scheduler()
+
+        with patch.object(scheduler.blizzard_client, "initialize", new_callable=AsyncMock), \
+             patch.dict(os.environ, {"APP_ENV": "production"}):
+            await scheduler.start()
+
+        ids_from_kwargs = [
+            c.kwargs.get("id") for c in scheduler.scheduler.add_job.call_args_list
+            if c.kwargs.get("id")
+        ]
+        assert "activity_prune" in ids_from_kwargs

--- a/tests/unit/test_activity_prune.py
+++ b/tests/unit/test_activity_prune.py
@@ -3,8 +3,10 @@
 Tests:
 1. run_activity_prune: executes DELETE with correct SQL
 2. run_activity_prune: logs completion message with result
-3. run_activity_prune: handles DB exception without propagating
-4. start() registers activity_prune job in production
+3. run_activity_prune: DB exception does not propagate
+4. run_activity_prune: DB exception calls report_error with warning severity
+5. run_activity_prune: DB exception calls maybe_notify_discord
+6. start() registers activity_prune job in production
 """
 
 import os
@@ -41,7 +43,7 @@ def _make_scheduler():
 
 
 # ---------------------------------------------------------------------------
-# 1–3. run_activity_prune behaviour
+# 1–5. run_activity_prune behaviour
 # ---------------------------------------------------------------------------
 
 
@@ -90,12 +92,50 @@ class TestRunActivityPrune:
         mock_pool_ctx.__aexit__ = AsyncMock(return_value=False)
         scheduler.db_pool.acquire = MagicMock(return_value=mock_pool_ctx)
 
-        # Should not raise
-        await scheduler.run_activity_prune()
+        with patch("sv_common.errors.report_error", new_callable=AsyncMock,
+                   return_value={"is_first_occurrence": True}), \
+             patch("guild_portal.services.error_routing.maybe_notify_discord", new_callable=AsyncMock):
+            # Should not raise
+            await scheduler.run_activity_prune()
+
+    @pytest.mark.asyncio
+    async def test_exception_calls_report_error_as_warning(self):
+        scheduler = _make_scheduler()
+
+        mock_pool_ctx = MagicMock()
+        mock_pool_ctx.__aenter__ = AsyncMock(side_effect=Exception("connection refused"))
+        mock_pool_ctx.__aexit__ = AsyncMock(return_value=False)
+        scheduler.db_pool.acquire = MagicMock(return_value=mock_pool_ctx)
+
+        with patch("sv_common.errors.report_error", new_callable=AsyncMock,
+                   return_value={"is_first_occurrence": True}) as mock_report, \
+             patch("guild_portal.services.error_routing.maybe_notify_discord", new_callable=AsyncMock):
+            await scheduler.run_activity_prune()
+
+        mock_report.assert_called_once()
+        args = mock_report.call_args[0]
+        assert args[1] == "activity_prune_failed"
+        assert args[2] == "warning"
+
+    @pytest.mark.asyncio
+    async def test_exception_calls_maybe_notify_discord(self):
+        scheduler = _make_scheduler()
+
+        mock_pool_ctx = MagicMock()
+        mock_pool_ctx.__aenter__ = AsyncMock(side_effect=Exception("connection refused"))
+        mock_pool_ctx.__aexit__ = AsyncMock(return_value=False)
+        scheduler.db_pool.acquire = MagicMock(return_value=mock_pool_ctx)
+
+        with patch("sv_common.errors.report_error", new_callable=AsyncMock,
+                   return_value={"is_first_occurrence": True}), \
+             patch("guild_portal.services.error_routing.maybe_notify_discord", new_callable=AsyncMock) as mock_notify:
+            await scheduler.run_activity_prune()
+
+        mock_notify.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
-# 4. start() registers activity_prune job
+# 6. start() registers activity_prune job
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit/test_admin_users_activity.py
+++ b/tests/unit/test_admin_users_activity.py
@@ -1,0 +1,271 @@
+"""Unit tests for Phase 1.8-C — Admin Users page activity columns.
+
+Tests:
+1-8.  _rel_time() helper — various time deltas
+9.    _rel_time(None) returns "never"
+10.   timezone-naive dt is handled without error
+11.   bnet_token_expired flag set correctly
+12.   pages_7d None coerced to empty list
+13.   pages_7d list passed through unchanged
+14.   last_active_rel / last_login_rel derived from rel_time
+15.   active_week count — user active in last 7 days
+16.   active_week count — user active 8 days ago excluded
+17.   active_week count — user with None last_active_at excluded
+18.   never_logged_in count — login_count 0
+19.   never_logged_in count — login_count > 0 excluded
+20.   ORDER BY last_active_at DESC NULLS LAST — verify SQL contains it
+"""
+
+import os
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+os.environ.setdefault("JWT_SECRET_KEY", "unit-test-secret-key-for-jwt-32chars!!")
+os.environ.setdefault("APP_ENV", "testing")
+
+
+from guild_portal.pages.admin_pages import _rel_time
+
+
+# ---------------------------------------------------------------------------
+# _rel_time helper
+# ---------------------------------------------------------------------------
+
+class TestRelTime:
+    def _ago(self, **kwargs) -> datetime:
+        return datetime.now(timezone.utc) - timedelta(**kwargs)
+
+    def test_none_returns_never(self):
+        assert _rel_time(None) == "never"
+
+    def test_just_now_seconds(self):
+        assert _rel_time(self._ago(seconds=30)) == "just now"
+
+    def test_just_now_59_seconds(self):
+        assert _rel_time(self._ago(seconds=59)) == "just now"
+
+    def test_minutes(self):
+        assert _rel_time(self._ago(minutes=5)) == "5m ago"
+
+    def test_minutes_59(self):
+        assert _rel_time(self._ago(minutes=59)) == "59m ago"
+
+    def test_hours(self):
+        assert _rel_time(self._ago(hours=3)) == "3h ago"
+
+    def test_hours_23(self):
+        assert _rel_time(self._ago(hours=23)) == "23h ago"
+
+    def test_days(self):
+        assert _rel_time(self._ago(days=5)) == "5d ago"
+
+    def test_days_29(self):
+        assert _rel_time(self._ago(days=29)) == "29d ago"
+
+    def test_months(self):
+        assert _rel_time(self._ago(days=60)) == "2mo ago"
+
+    def test_years(self):
+        assert _rel_time(self._ago(days=400)) == "1y ago"
+
+    def test_naive_datetime_handled(self):
+        # timezone-naive dt should not raise
+        naive = datetime.utcnow() - timedelta(hours=2)
+        result = _rel_time(naive)
+        assert result == "2h ago"
+
+
+# ---------------------------------------------------------------------------
+# Row processing logic
+# ---------------------------------------------------------------------------
+
+def _make_raw_row(
+    *,
+    id=1,
+    email="test@example.com",
+    is_active=True,
+    created_at=None,
+    last_login_at=None,
+    last_active_at=None,
+    login_count=0,
+    player_id=None,
+    display_name=None,
+    rank_name=None,
+    battletag=None,
+    last_bnet_sync=None,
+    bnet_token_expires_at=None,
+    views_7d=0,
+    views_total=0,
+    last_activity_date=None,
+    pages_7d=None,
+):
+    return {
+        "id": id,
+        "email": email,
+        "is_active": is_active,
+        "created_at": created_at or datetime.now(timezone.utc),
+        "last_login_at": last_login_at,
+        "last_active_at": last_active_at,
+        "login_count": login_count,
+        "player_id": player_id,
+        "display_name": display_name,
+        "rank_name": rank_name,
+        "battletag": battletag,
+        "last_bnet_sync": last_bnet_sync,
+        "bnet_token_expires_at": bnet_token_expires_at,
+        "views_7d": views_7d,
+        "views_total": views_total,
+        "last_activity_date": last_activity_date,
+        "pages_7d": pages_7d,
+    }
+
+
+def _process_row(raw: dict) -> dict:
+    """Mirror the processing logic in admin_users()."""
+    now = datetime.now(timezone.utc)
+    u = dict(raw)
+    expires_at = u.get("bnet_token_expires_at")
+    u["bnet_token_expired"] = bool(expires_at and expires_at <= now)
+    u["last_active_rel"] = _rel_time(u.get("last_active_at"))
+    u["last_login_rel"] = _rel_time(u.get("last_login_at"))
+    u["pages_7d"] = u.get("pages_7d") or []
+    return u
+
+
+class TestRowProcessing:
+    def test_bnet_token_not_expired(self):
+        expires = datetime.now(timezone.utc) + timedelta(hours=1)
+        u = _process_row(_make_raw_row(bnet_token_expires_at=expires))
+        assert u["bnet_token_expired"] is False
+
+    def test_bnet_token_expired(self):
+        expires = datetime.now(timezone.utc) - timedelta(hours=1)
+        u = _process_row(_make_raw_row(bnet_token_expires_at=expires))
+        assert u["bnet_token_expired"] is True
+
+    def test_bnet_token_none_not_expired(self):
+        u = _process_row(_make_raw_row(bnet_token_expires_at=None))
+        assert u["bnet_token_expired"] is False
+
+    def test_pages_7d_none_becomes_empty_list(self):
+        u = _process_row(_make_raw_row(pages_7d=None))
+        assert u["pages_7d"] == []
+
+    def test_pages_7d_list_passed_through(self):
+        paths = ["/admin/users", "/roster"]
+        u = _process_row(_make_raw_row(pages_7d=paths))
+        assert u["pages_7d"] == paths
+
+    def test_last_active_rel_populated(self):
+        active = datetime.now(timezone.utc) - timedelta(hours=2)
+        u = _process_row(_make_raw_row(last_active_at=active))
+        assert u["last_active_rel"] == "2h ago"
+
+    def test_last_active_rel_never(self):
+        u = _process_row(_make_raw_row(last_active_at=None))
+        assert u["last_active_rel"] == "never"
+
+    def test_last_login_rel_populated(self):
+        login = datetime.now(timezone.utc) - timedelta(days=3)
+        u = _process_row(_make_raw_row(last_login_at=login))
+        assert u["last_login_rel"] == "3d ago"
+
+    def test_last_login_rel_never(self):
+        u = _process_row(_make_raw_row(last_login_at=None))
+        assert u["last_login_rel"] == "never"
+
+
+# ---------------------------------------------------------------------------
+# Stat pill computation
+# ---------------------------------------------------------------------------
+
+def _compute_stats(users: list[dict]) -> dict:
+    """Mirror active_week / never_logged_in computation from admin_users()."""
+    now = datetime.now(timezone.utc)
+    active_week = sum(
+        1 for u in users
+        if u.get("last_active_at") is not None
+        and (now - (
+            u["last_active_at"].replace(tzinfo=timezone.utc)
+            if u["last_active_at"].tzinfo is None
+            else u["last_active_at"]
+        )).days < 7
+    )
+    never_logged_in = sum(1 for u in users if not u.get("login_count"))
+    return {"active_week": active_week, "never_logged_in": never_logged_in}
+
+
+class TestStatPills:
+    def test_active_week_recent_user(self):
+        users = [
+            _make_raw_row(last_active_at=datetime.now(timezone.utc) - timedelta(days=2)),
+        ]
+        s = _compute_stats(users)
+        assert s["active_week"] == 1
+
+    def test_active_week_excludes_old(self):
+        users = [
+            _make_raw_row(last_active_at=datetime.now(timezone.utc) - timedelta(days=8)),
+        ]
+        s = _compute_stats(users)
+        assert s["active_week"] == 0
+
+    def test_active_week_excludes_none(self):
+        users = [_make_raw_row(last_active_at=None)]
+        s = _compute_stats(users)
+        assert s["active_week"] == 0
+
+    def test_active_week_mixed(self):
+        users = [
+            _make_raw_row(id=1, last_active_at=datetime.now(timezone.utc) - timedelta(days=1)),
+            _make_raw_row(id=2, last_active_at=datetime.now(timezone.utc) - timedelta(days=10)),
+            _make_raw_row(id=3, last_active_at=None),
+        ]
+        s = _compute_stats(users)
+        assert s["active_week"] == 1
+
+    def test_never_logged_in_zero_count(self):
+        users = [_make_raw_row(login_count=0)]
+        s = _compute_stats(users)
+        assert s["never_logged_in"] == 1
+
+    def test_never_logged_in_excludes_nonzero(self):
+        users = [_make_raw_row(login_count=5)]
+        s = _compute_stats(users)
+        assert s["never_logged_in"] == 0
+
+    def test_never_logged_in_mixed(self):
+        users = [
+            _make_raw_row(id=1, login_count=0),
+            _make_raw_row(id=2, login_count=3),
+            _make_raw_row(id=3, login_count=0),
+        ]
+        s = _compute_stats(users)
+        assert s["never_logged_in"] == 2
+
+
+# ---------------------------------------------------------------------------
+# SQL sanity check
+# ---------------------------------------------------------------------------
+
+class TestAdminUsersSql:
+    def test_query_orders_by_last_active_at(self):
+        import inspect
+        from guild_portal.pages import admin_pages
+        src = inspect.getsource(admin_pages.admin_users)
+        assert "last_active_at DESC NULLS LAST" in src
+
+    def test_query_selects_activity_columns(self):
+        import inspect
+        from guild_portal.pages import admin_pages
+        src = inspect.getsource(admin_pages.admin_users)
+        for col in ("views_7d", "views_total", "pages_7d", "last_login_at", "login_count"):
+            assert col in src, f"Expected '{col}' in admin_users SQL"
+
+    def test_query_joins_user_activity(self):
+        import inspect
+        from guild_portal.pages import admin_pages
+        src = inspect.getsource(admin_pages.admin_users)
+        assert "user_activity" in src

--- a/tests/unit/test_user_activity_phase_a.py
+++ b/tests/unit/test_user_activity_phase_a.py
@@ -1,0 +1,234 @@
+"""Unit tests for Phase 1.8-A — user activity logging schema + login stamping.
+
+Tests:
+1. User model has last_active_at column
+2. User model has last_login_at column
+3. User model has login_count column with default 0
+4. Migration 0178 exists with correct revision chain
+5. login_count increments on each successful login call
+6. last_login_at is stamped on successful login
+7. login_count is NOT incremented on failed login (bad password)
+8. login_count is NOT incremented on inactive account
+"""
+
+import os
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch, call
+
+import pytest
+
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+os.environ.setdefault("JWT_SECRET_KEY", "unit-test-secret-key-for-jwt-32chars!!")
+os.environ.setdefault("APP_ENV", "testing")
+
+
+# ---------------------------------------------------------------------------
+# Model column presence
+# ---------------------------------------------------------------------------
+
+
+class TestUserModelColumns:
+    def test_user_has_last_active_at(self):
+        from sv_common.db.models import User
+        assert hasattr(User, "last_active_at")
+
+    def test_user_has_last_login_at(self):
+        from sv_common.db.models import User
+        assert hasattr(User, "last_login_at")
+
+    def test_user_has_login_count(self):
+        from sv_common.db.models import User
+        assert hasattr(User, "login_count")
+
+    def test_user_login_count_column_name(self):
+        from sv_common.db.models import User
+        col = User.__table__.c.get("login_count")
+        assert col is not None
+
+    def test_user_last_login_at_nullable(self):
+        from sv_common.db.models import User
+        col = User.__table__.c.get("last_login_at")
+        assert col is not None
+        assert col.nullable is True
+
+    def test_user_last_active_at_nullable(self):
+        from sv_common.db.models import User
+        col = User.__table__.c.get("last_active_at")
+        assert col is not None
+        assert col.nullable is True
+
+
+# ---------------------------------------------------------------------------
+# Migration file
+# ---------------------------------------------------------------------------
+
+
+class TestMigration0178:
+    def test_migration_file_exists(self):
+        import os
+        base = os.path.dirname(__file__)
+        migration = os.path.join(base, "..", "..", "alembic", "versions", "0178_user_activity_logging.py")
+        assert os.path.isfile(migration), "Migration 0178 file not found"
+
+    def test_migration_revision(self):
+        import importlib.util, os
+        base = os.path.dirname(__file__)
+        path = os.path.join(base, "..", "..", "alembic", "versions", "0178_user_activity_logging.py")
+        spec = importlib.util.spec_from_file_location("m0178", path)
+        m = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(m)
+        assert m.revision == "0178"
+        assert m.down_revision == "0177"
+
+
+# ---------------------------------------------------------------------------
+# Login stamping
+# ---------------------------------------------------------------------------
+
+
+def _make_user(*, is_active=True, login_count=0, last_login_at=None):
+    user = MagicMock()
+    user.id = 1
+    user.is_active = is_active
+    user.password_hash = "$2b$12$placeholder"
+    user.login_count = login_count
+    user.last_login_at = last_login_at
+    return user
+
+
+def _make_player(*, rank_level=2):
+    player = MagicMock()
+    player.id = 10
+    player.website_user_id = 1
+    player.guild_rank = MagicMock()
+    player.guild_rank.level = rank_level
+    return player
+
+
+def _make_db(user, player):
+    """Return a mock AsyncSession that returns user then player from execute()."""
+    user_scalar = MagicMock()
+    user_scalar.scalar_one_or_none = MagicMock(return_value=user)
+    player_scalar = MagicMock()
+    player_scalar.scalar_one_or_none = MagicMock(return_value=player)
+
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[user_scalar, player_scalar])
+    db.flush = AsyncMock()
+    return db
+
+
+class TestLoginStamping:
+    @pytest.mark.asyncio
+    async def test_last_login_at_set_on_success(self):
+        from guild_portal.api.auth_routes import login, LoginBody
+        from sv_common.auth.passwords import hash_password
+
+        user = _make_user()
+        user.password_hash = hash_password("password123")
+        player = _make_player()
+        db = _make_db(user, player)
+
+        body = LoginBody(discord_username="testuser", password="password123")
+        result = await login(body, db)
+
+        assert result["ok"] is True
+        assert user.last_login_at is not None
+        assert isinstance(user.last_login_at, datetime)
+
+    @pytest.mark.asyncio
+    async def test_login_count_incremented_on_success(self):
+        from guild_portal.api.auth_routes import login, LoginBody
+        from sv_common.auth.passwords import hash_password
+
+        user = _make_user(login_count=5)
+        user.password_hash = hash_password("password123")
+        player = _make_player()
+        db = _make_db(user, player)
+
+        body = LoginBody(discord_username="testuser", password="password123")
+        await login(body, db)
+
+        assert user.login_count == 6
+
+    @pytest.mark.asyncio
+    async def test_login_count_starts_from_zero(self):
+        from guild_portal.api.auth_routes import login, LoginBody
+        from sv_common.auth.passwords import hash_password
+
+        user = _make_user(login_count=0)
+        user.password_hash = hash_password("password123")
+        player = _make_player()
+        db = _make_db(user, player)
+
+        body = LoginBody(discord_username="testuser", password="password123")
+        await login(body, db)
+
+        assert user.login_count == 1
+
+    @pytest.mark.asyncio
+    async def test_db_flush_called_after_stamping(self):
+        from guild_portal.api.auth_routes import login, LoginBody
+        from sv_common.auth.passwords import hash_password
+
+        user = _make_user()
+        user.password_hash = hash_password("password123")
+        player = _make_player()
+        db = _make_db(user, player)
+
+        body = LoginBody(discord_username="testuser", password="password123")
+        await login(body, db)
+
+        db.flush.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_login_count_not_incremented_on_bad_password(self):
+        from guild_portal.api.auth_routes import login, LoginBody
+        from sv_common.auth.passwords import hash_password
+        from fastapi import HTTPException
+
+        user = _make_user(login_count=3)
+        user.password_hash = hash_password("correct_password")
+        db = _make_db(user, _make_player())
+
+        body = LoginBody(discord_username="testuser", password="wrong_password")
+        with pytest.raises(HTTPException) as exc:
+            await login(body, db)
+
+        assert exc.value.status_code == 401
+        assert user.login_count == 3  # unchanged
+
+    @pytest.mark.asyncio
+    async def test_login_count_not_incremented_on_unknown_user(self):
+        from guild_portal.api.auth_routes import login, LoginBody
+        from fastapi import HTTPException
+
+        # User not found — scalar_one_or_none returns None
+        scalar = MagicMock()
+        scalar.scalar_one_or_none = MagicMock(return_value=None)
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=scalar)
+
+        body = LoginBody(discord_username="ghost", password="any")
+        with pytest.raises(HTTPException) as exc:
+            await login(body, db)
+
+        assert exc.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_inactive_user_blocked_before_stamping(self):
+        from guild_portal.api.auth_routes import login, LoginBody
+        from sv_common.auth.passwords import hash_password
+        from fastapi import HTTPException
+
+        user = _make_user(is_active=False, login_count=0)
+        user.password_hash = hash_password("password123")
+        db = _make_db(user, _make_player())
+
+        body = LoginBody(discord_username="testuser", password="password123")
+        with pytest.raises(HTTPException) as exc:
+            await login(body, db)
+
+        assert exc.value.status_code == 403
+        assert user.login_count == 0  # not incremented for inactive accounts
+        assert user.last_login_at is None


### PR DESCRIPTION
## Summary

- `common.users` — adds `last_active_at`, `last_login_at`, `login_count` (migration 0178)
- `common.user_activity` — daily rollup table, one row per user per UTC date
- Login stamping on both `POST /api/v1/auth/login` and `POST /login` (form handler)
- `ActivityMiddleware` — background upsert after each authenticated response; skips static/polling paths
- Admin Users page — activity columns (Last Active, Last Login, Logins, 7d Views), stat pills, expandable page-visit tags, sorted by last active
- Weekly retention prune job (Sunday 3:30 AM UTC, 90-day window) with `report_error` on failure

## Test plan
- [ ] 1876/1882 unit tests pass (6 pre-existing failures)
- [ ] Deployed and verified on dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)