### PR TITLE
fix: fetch Blizzard item icons during equipment sync

### DIFF
--- a/src/guild_portal/services/gear_plan_service.py
+++ b/src/guild_portal/services/gear_plan_service.py
@@ -1110,14 +1110,18 @@ async def get_plan_detail(
         hero_talent_id = plan_row["hero_talent_id"]
         bis_source_id = plan_row["bis_source_id"]
 
-        # Equipped gear
+        # Equipped gear — COALESCE icon_url from enrichment (post-rebuild) then
+        # landing.blizzard_item_icons (populated during equipment sync) so newly
+        # equipped items show icons immediately without requiring a manual rebuild.
         equip_rows = await conn.fetch(
             """
             SELECT ce.slot, ce.blizzard_item_id, ce.item_name, ce.item_level,
                    ce.quality_track, ce.enchant_id, ce.gem_ids, ce.bonus_ids,
-                   ei.icon_url, ei.slot_type
+                   COALESCE(ei.icon_url, bii.icon_url) AS icon_url,
+                   ei.slot_type
               FROM guild_identity.character_equipment ce
               LEFT JOIN enrichment.items ei ON ei.blizzard_item_id = ce.blizzard_item_id
+              LEFT JOIN landing.blizzard_item_icons bii ON bii.blizzard_item_id = ce.blizzard_item_id
              WHERE ce.character_id = $1
             """,
             character_id,

--- a/src/sv_common/guild_sync/equipment_sync.py
+++ b/src/sv_common/guild_sync/equipment_sync.py
@@ -144,6 +144,8 @@ async def _sync_one_character(
         logger.debug("No equipment data for %s/%s", realm_slug, char_name)
         return False
 
+    item_ids = [s.blizzard_item_id for s in slots if s.blizzard_item_id]
+
     async with pool.acquire() as conn:
         async with conn.transaction():
             for slot_data in slots:
@@ -186,4 +188,51 @@ async def _sync_one_character(
                 now, char_id,
             )
 
+    # Best-effort: fetch icons for any equipped item not yet in landing.blizzard_item_icons
+    await _fetch_missing_item_icons(pool, blizzard_client, item_ids, char_name)
+
     return True
+
+
+async def _fetch_missing_item_icons(
+    pool: asyncpg.Pool,
+    blizzard_client: BlizzardClient,
+    item_ids: list[int],
+    char_name: str,
+) -> None:
+    """Fetch and cache Blizzard media icons for equipped items not yet in landing."""
+    if not item_ids:
+        return
+
+    async with pool.acquire() as conn:
+        existing = await conn.fetch(
+            "SELECT blizzard_item_id FROM landing.blizzard_item_icons WHERE blizzard_item_id = ANY($1::int[])",
+            item_ids,
+        )
+    already_cached = {r["blizzard_item_id"] for r in existing}
+    missing = [iid for iid in item_ids if iid not in already_cached]
+
+    if not missing:
+        return
+
+    logger.debug(
+        "Fetching icons for %d uncached equipped items on %s", len(missing), char_name
+    )
+    for item_id in missing:
+        try:
+            icon_url = await blizzard_client.get_item_media(item_id)
+            if icon_url:
+                async with pool.acquire() as conn:
+                    await conn.execute(
+                        """
+                        INSERT INTO landing.blizzard_item_icons (blizzard_item_id, icon_url)
+                        VALUES ($1, $2)
+                        ON CONFLICT (blizzard_item_id)
+                        DO UPDATE SET icon_url = EXCLUDED.icon_url, fetched_at = NOW()
+                        """,
+                        item_id, icon_url,
+                    )
+        except Exception as exc:
+            logger.warning(
+                "Icon fetch failed for item %d (char %s): %s", item_id, char_name, exc
+            )

--- a/tests/unit/test_equipment_icon_fetch.py
+++ b/tests/unit/test_equipment_icon_fetch.py
@@ -1,0 +1,139 @@
+"""Unit tests for _fetch_missing_item_icons in equipment_sync.py."""
+
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+
+from sv_common.guild_sync.equipment_sync import _fetch_missing_item_icons
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_pool(existing_ids: list[int]) -> MagicMock:
+    """Return a mock pool whose blizzard_item_icons table contains existing_ids."""
+    conn = AsyncMock()
+    conn.fetch = AsyncMock(
+        return_value=[{"blizzard_item_id": iid} for iid in existing_ids]
+    )
+    conn.execute = AsyncMock()
+
+    pool = MagicMock()
+    pool.acquire = MagicMock(return_value=_AsyncContextManager(conn))
+    return pool, conn
+
+
+class _AsyncContextManager:
+    def __init__(self, value):
+        self._value = value
+
+    async def __aenter__(self):
+        return self._value
+
+    async def __aexit__(self, *args):
+        pass
+
+
+def _make_client(icon_map: dict[int, str | None]) -> MagicMock:
+    """Return a mock BlizzardClient whose get_item_media returns from icon_map."""
+    client = MagicMock()
+    client.get_item_media = AsyncMock(side_effect=lambda iid: icon_map.get(iid))
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestFetchMissingItemIcons:
+    @pytest.mark.asyncio
+    async def test_no_item_ids_is_noop(self):
+        pool, conn = _make_pool([])
+        client = _make_client({})
+
+        await _fetch_missing_item_icons(pool, client, [], "Trogmoon")
+
+        conn.fetch.assert_not_called()
+        client.get_item_media.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_all_already_cached_skips_fetch(self):
+        pool, conn = _make_pool([111, 222])
+        client = _make_client({})
+
+        await _fetch_missing_item_icons(pool, client, [111, 222], "Trogmoon")
+
+        client.get_item_media.assert_not_called()
+        conn.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_items_are_fetched_and_inserted(self):
+        pool, conn = _make_pool([111])  # 111 already cached, 222 is missing
+        client = _make_client({222: "https://wow.zamimg.com/icons/medium/inv_sword_01.jpg"})
+
+        # Need a second conn for the INSERT — reuse same mock
+        await _fetch_missing_item_icons(pool, client, [111, 222], "Trogmoon")
+
+        client.get_item_media.assert_called_once_with(222)
+        conn.execute.assert_called_once()
+        sql, item_id, icon_url = conn.execute.call_args.args
+        assert item_id == 222
+        assert "inv_sword_01" in icon_url
+
+    @pytest.mark.asyncio
+    async def test_none_icon_url_is_not_inserted(self):
+        pool, conn = _make_pool([])
+        client = _make_client({333: None})
+
+        await _fetch_missing_item_icons(pool, client, [333], "Trogmoon")
+
+        client.get_item_media.assert_called_once_with(333)
+        conn.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fetch_exception_is_swallowed(self):
+        pool, conn = _make_pool([])
+        client = MagicMock()
+        client.get_item_media = AsyncMock(side_effect=Exception("network error"))
+
+        # Should not raise
+        await _fetch_missing_item_icons(pool, client, [444], "Trogmoon")
+
+        conn.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_multiple_missing_items_fetched_individually(self):
+        pool, conn = _make_pool([])
+        client = _make_client(
+            {
+                10: "https://wow.zamimg.com/icons/medium/a.jpg",
+                20: "https://wow.zamimg.com/icons/medium/b.jpg",
+            }
+        )
+
+        await _fetch_missing_item_icons(pool, client, [10, 20], "Trogmoon")
+
+        assert client.get_item_media.call_count == 2
+        assert conn.execute.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_partial_failure_still_inserts_successful_items(self):
+        pool, conn = _make_pool([])
+
+        async def _media(iid: int):
+            if iid == 10:
+                raise Exception("timeout")
+            return "https://wow.zamimg.com/icons/medium/b.jpg"
+
+        client = MagicMock()
+        client.get_item_media = AsyncMock(side_effect=_media)
+
+        await _fetch_missing_item_icons(pool, client, [10, 20], "Trogmoon")
+
+        # item 10 failed but item 20 should still be inserted
+        assert conn.execute.call_count == 1
+        _, item_id, _ = conn.execute.call_args.args
+        assert item_id == 20


### PR DESCRIPTION
## Summary
- Adds `_fetch_missing_item_icons()` to `equipment_sync.py` — after each character's equipment is saved, any `blizzard_item_id` not yet in `landing.blizzard_item_icons` is fetched via `get_item_media()` and stored
- Updates the equipped-items query in `gear_plan_service.py` to `COALESCE(enrichment.items.icon_url, landing.blizzard_item_icons.icon_url)` so icons show immediately without a manual Enrich & Classify rebuild
- Fires on both the manual "Sync Now" button and the 4x-daily scheduled Blizzard sync

## Test plan
- [x] 7 unit tests covering: no-op on empty list, all-cached skip, fetch+insert for missing, null icon not inserted, exception swallowed, multiple items, partial failure
- [x] Full unit suite: 1885 passed (6 pre-existing failures unrelated to this change)
- [x] Validated on dev — weapon and off-hand icons now appear after equipment sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)