### PR TITLE
fix: evict stale duplicate row before rename/realm-transfer UPDATE

### DIFF
--- a/src/sv_common/guild_sync/db_sync.py
+++ b/src/sv_common/guild_sync/db_sync.py
@@ -110,6 +110,38 @@ async def sync_blizzard_roster(
                         old_key = (renamed_from.lower(), existing["realm_slug"].lower())
                         current_keys.discard(old_key)
 
+                    # If character_name or realm_slug is changing (rename or realm transfer),
+                    # evict any row that already holds the target (name, realm) combination.
+                    # Without this, the UPDATE below raises a unique constraint violation when
+                    # a soft-deleted row from a prior stint exists with the same name+realm.
+                    target_name_changed = char.character_name.lower() != existing["character_name"].lower()
+                    target_realm_changed = char.realm_slug.lower() != existing["realm_slug"].lower()
+                    if target_name_changed or target_realm_changed:
+                        conflict = await conn.fetchrow(
+                            """SELECT id, removed_at FROM guild_identity.wow_characters
+                               WHERE LOWER(character_name) = $1 AND LOWER(realm_slug) = $2
+                                 AND id != $3""",
+                            char.character_name.lower(), char.realm_slug.lower(), existing["id"],
+                        )
+                        if conflict:
+                            change_type = "rename" if target_name_changed else "realm transfer"
+                            if conflict["removed_at"] is not None:
+                                logger.info(
+                                    "Evicting stale removed row id=%s (%s/%s) ahead of %s update",
+                                    conflict["id"], char.character_name, char.realm_slug, change_type,
+                                )
+                            else:
+                                logger.warning(
+                                    "Evicting unexpected live duplicate row id=%s (%s/%s) "
+                                    "ahead of %s; stable-ID row id=%s takes precedence",
+                                    conflict["id"], char.character_name, char.realm_slug,
+                                    change_type, existing["id"],
+                                )
+                            await conn.execute(
+                                "DELETE FROM guild_identity.wow_characters WHERE id = $1",
+                                conflict["id"],
+                            )
+
                     await conn.execute(
                         """UPDATE guild_identity.wow_characters SET
                             character_name = $2,

--- a/tests/unit/test_db_sync.py
+++ b/tests/unit/test_db_sync.py
@@ -260,6 +260,153 @@ async def test_renamed_character_not_marked_removed():
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# sync_blizzard_roster — stale-row eviction before rename/realm-transfer UPDATE
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rename_evicts_stale_removed_row():
+    """Rename detected + stale removed row at target name/realm → row deleted before UPDATE."""
+    from sv_common.guild_sync.db_sync import sync_blizzard_roster
+
+    pool, conn = _make_pool()
+
+    fetchrow_calls = []
+
+    async def fake_fetchrow(query, *args):
+        fetchrow_calls.append((query, args))
+        if "blizzard_character_id = $1" in query:
+            return {"id": 10, "character_name": "Oldname", "realm_slug": "bloodscalp", "removed_at": None}
+        if "LOWER(character_name)" in query and "id != $3" in query:
+            # Conflict check: stale removed row with target name+realm
+            from datetime import datetime, timezone
+            return {"id": 99, "removed_at": datetime(2025, 1, 1, tzinfo=timezone.utc)}
+        if "classes" in query:
+            return {"id": 11}
+        if "specializations" in query:
+            return {"id": 3}
+        return None
+
+    conn.fetch.side_effect = [
+        [{"wow_rank_index": 3, "id": 50}],  # _build_rank_index_map
+        [{"id": 10, "character_name": "Maplehoof", "realm_slug": "bloodscalp"}],  # all_active
+    ]
+    conn.fetchrow.side_effect = fake_fetchrow
+
+    chars = [_char(name="Maplehoof", realm="bloodscalp", blizzard_id=42)]
+    stats = await sync_blizzard_roster(pool, chars)
+
+    assert stats["updated"] == 1
+
+    # Stale row id=99 must have been deleted
+    delete_calls = [c for c in conn.execute.call_args_list if "DELETE" in str(c)]
+    assert len(delete_calls) == 1
+    assert 99 in delete_calls[0].args
+
+
+@pytest.mark.asyncio
+async def test_realm_transfer_back_evicts_stale_removed_row():
+    """Character transfers back to original realm; stale removed row evicted before UPDATE."""
+    from sv_common.guild_sync.db_sync import sync_blizzard_roster
+
+    pool, conn = _make_pool()
+
+    async def fake_fetchrow(query, *args):
+        if "blizzard_character_id = $1" in query:
+            # Found by stable ID, but currently on a different realm
+            return {"id": 10, "character_name": "Maplehoof", "realm_slug": "other-realm", "removed_at": None}
+        if "LOWER(character_name)" in query and "id != $3" in query:
+            # Conflict check: stale removed row on bloodscalp
+            from datetime import datetime, timezone
+            return {"id": 77, "removed_at": datetime(2025, 6, 1, tzinfo=timezone.utc)}
+        if "classes" in query:
+            return {"id": 11}
+        if "specializations" in query:
+            return {"id": 3}
+        return None
+
+    conn.fetch.side_effect = [
+        [{"wow_rank_index": 3, "id": 50}],
+        [{"id": 10, "character_name": "Maplehoof", "realm_slug": "bloodscalp"}],
+    ]
+    conn.fetchrow.side_effect = fake_fetchrow
+
+    chars = [_char(name="Maplehoof", realm="bloodscalp", blizzard_id=42)]
+    stats = await sync_blizzard_roster(pool, chars)
+
+    assert stats["updated"] == 1
+
+    delete_calls = [c for c in conn.execute.call_args_list if "DELETE" in str(c)]
+    assert len(delete_calls) == 1
+    assert 77 in delete_calls[0].args
+
+
+@pytest.mark.asyncio
+async def test_no_conflict_no_eviction():
+    """Rename detected but no conflicting row exists — no DELETE issued."""
+    from sv_common.guild_sync.db_sync import sync_blizzard_roster
+
+    pool, conn = _make_pool()
+
+    async def fake_fetchrow(query, *args):
+        if "blizzard_character_id = $1" in query:
+            return {"id": 10, "character_name": "Oldname", "realm_slug": "senjin", "removed_at": None}
+        if "LOWER(character_name)" in query and "id != $3" in query:
+            return None  # no conflict
+        if "classes" in query:
+            return {"id": 11}
+        if "specializations" in query:
+            return {"id": 3}
+        return None
+
+    conn.fetch.side_effect = [
+        [{"wow_rank_index": 3, "id": 50}],
+        [{"id": 10, "character_name": "Newname", "realm_slug": "senjin"}],
+    ]
+    conn.fetchrow.side_effect = fake_fetchrow
+
+    chars = [_char(name="Newname", realm="senjin", blizzard_id=42)]
+    stats = await sync_blizzard_roster(pool, chars)
+
+    assert stats["updated"] == 1
+    delete_calls = [c for c in conn.execute.call_args_list if "DELETE" in str(c)]
+    assert len(delete_calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_no_name_or_realm_change_skips_conflict_check():
+    """Stable ID found, name and realm unchanged — conflict check query not issued."""
+    from sv_common.guild_sync.db_sync import sync_blizzard_roster
+
+    pool, conn = _make_pool()
+
+    conflict_queries = []
+
+    async def fake_fetchrow(query, *args):
+        if "blizzard_character_id = $1" in query:
+            return {"id": 10, "character_name": "Testchar", "realm_slug": "senjin", "removed_at": None}
+        if "id != $3" in query:
+            conflict_queries.append(query)
+            return None
+        if "classes" in query:
+            return {"id": 11}
+        if "specializations" in query:
+            return {"id": 3}
+        return None
+
+    conn.fetch.side_effect = [
+        [{"wow_rank_index": 3, "id": 50}],
+        [{"id": 10, "character_name": "Testchar", "realm_slug": "senjin"}],
+    ]
+    conn.fetchrow.side_effect = fake_fetchrow
+
+    chars = [_char(name="Testchar", realm="senjin", blizzard_id=42)]
+    await sync_blizzard_roster(pool, chars)
+
+    assert len(conflict_queries) == 0
+
+
 @pytest.mark.asyncio
 async def test_no_blizzard_id_falls_back_to_name_lookup():
     """Character with no blizzard_character_id still matches by name+realm."""


### PR DESCRIPTION
## Summary
- Fixes `duplicate key value violates unique constraint "wow_characters_character_name_realm_slug_key"` crash in Blizzard roster sync
- Root cause: UPDATE setting new `character_name`/`realm_slug` on the stable-ID row collided with an old soft-deleted row already occupying that `(name, realm)` slot
- Fix: detect the conflict before the UPDATE and DELETE the stale row; info log for soft-deleted rows, warning for unexpected live duplicates
- No migration needed

## Test plan
- [x] 4 new unit tests: rename-conflict eviction, realm-transfer-back eviction, no-conflict (no DELETE), unchanged name+realm (skips conflict check entirely)
- [x] All 10 `test_db_sync.py` tests pass; 1889 suite-wide pass (6 pre-existing failures unrelated)
- [x] Deployed to dev successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)