### PR TITLE
fix: lower create_raid_event rank requirement to 3 (Veteran+)

### DIFF
--- a/src/guild_portal/api/admin_routes.py
+++ b/src/guild_portal/api/admin_routes.py
@@ -1030,7 +1030,7 @@ class RaidEventCreate(BaseModel):
 async def create_raid_event(
     body: RaidEventCreate,
     db: AsyncSession = Depends(get_db),
-    admin: Player = Depends(require_rank(4)),
+    admin: Player = Depends(require_rank(3)),
 ):
     """Create a raid event in Raid-Helper and store in patt.raid_events."""
     import zoneinfo


### PR DESCRIPTION
## Summary
- Raid Tools page was accessible at rank 3 (Veteran) but `POST /api/v1/admin/raid-events` required rank 4 (Officer)
- Wyland (Veteran) could see the Create Event form but got a silent 403 when submitting
- Lowered the API endpoint to `require_rank(3)` to match the page access level

## Test plan
- [x] Deployed to dev
- [ ] Verify Wyland (rank 3) can create an event end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)