### PR TITLE
fix: align JWT expiry to 30-day session cookie

### DIFF
--- a/src/guild_portal/config.py
+++ b/src/guild_portal/config.py
@@ -9,7 +9,7 @@ class Settings(BaseSettings):
     database_url: str
     jwt_secret_key: str
     jwt_algorithm: str = "HS256"
-    jwt_expire_minutes: int = 1440
+    jwt_expire_minutes: int = 43200  # 30 days — matches COOKIE_MAX_AGE in auth_pages.py
     discord_bot_token: str = ""
     discord_guild_id: str = ""
     google_apps_script_url: str = ""


### PR DESCRIPTION
## Summary
- Cookie `max_age` was set to 30 days in `auth_pages.py` but `JWT_EXPIRE_MINUTES` defaulted to 1440 (24 hours)
- After 24 hours, browser retains a valid cookie carrying an expired JWT — every API call returns 401
- Page-level auth (`get_page_member`) silently swallows `ExpiredSignatureError`, so the UI renders but all gear plan API calls fail with "Could Not Load Available Items"
- Fix: change the default in `config.py` from 1440 → 43200 (30 days) so tokens match cookie lifetime
- Dev/test `.env` files keep `JWT_EXPIRE_MINUTES=1440` explicitly, so test environments are unaffected

## Test plan
- [ ] After deploy, log out and log back in on prod — new token lasts 30 days
- [ ] Existing expired-token users just need to log in once; all subsequent API calls work
- [ ] Dev/test still expire at 24h (`.env` override takes precedence over code default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)